### PR TITLE
Fix: meal planner AI no longer writes full recipes in chat

### DIFF
--- a/recipe-app/app/DashboardClient.tsx
+++ b/recipe-app/app/DashboardClient.tsx
@@ -1,16 +1,19 @@
 "use client"
 
 import Link from "next/link"
-import { Plus, BookOpen, Utensils } from "lucide-react"
+import { Plus, BookOpen, Utensils, Dumbbell } from "lucide-react"
 import { useRecipes } from "@/lib/hooks/useRecipes"
 import { useMeals } from "@/lib/hooks/useMeals"
+import { useMealPreps } from "@/lib/hooks/useMealPreps"
 import { RecipeCard } from "@/components/recipe/RecipeCard"
 import { MealCard } from "@/components/meal/MealCard"
+import { MealPrepCard } from "@/components/meal-prep/MealPrepCard"
 import { EmptyState } from "@/components/layout/EmptyState"
 
 export function DashboardClient() {
   const recipes = useRecipes()
   const meals = useMeals()
+  const mealPreps = useMealPreps()
 
   return (
     <div className="max-w-6xl mx-auto px-4 py-8">
@@ -54,7 +57,7 @@ export function DashboardClient() {
       </div>
 
       {/* Meals section */}
-      <div>
+      <div className="mb-12">
         <div className="flex items-center justify-between mb-5">
           <h2 className="text-xl font-bold" style={{ color: "var(--color-foreground)" }}>
             Meals
@@ -87,6 +90,45 @@ export function DashboardClient() {
           <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-4">
             {meals.map((meal) => (
               <MealCard key={meal.id} meal={meal} />
+            ))}
+          </div>
+        )}
+      </div>
+
+      {/* Meal Prep section */}
+      <div>
+        <div className="flex items-center justify-between mb-5">
+          <h2 className="text-xl font-bold" style={{ color: "var(--color-foreground)" }}>
+            Meal Prep
+          </h2>
+          <Link
+            href="/meal-prep/new"
+            className="flex items-center gap-1.5 px-3 py-1.5 rounded-lg text-sm font-medium transition-colors"
+            style={{ color: "#065F46", backgroundColor: "#ECFDF5" }}
+          >
+            <Plus size={14} />
+            New Prep
+          </Link>
+        </div>
+
+        {mealPreps === undefined ? (
+          <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-4">
+            {[1, 2].map((i) => (
+              <div key={i} className="h-28 rounded-2xl animate-pulse"
+                style={{ backgroundColor: "var(--color-muted)" }} />
+            ))}
+          </div>
+        ) : mealPreps.length === 0 ? (
+          <EmptyState
+            icon={Dumbbell}
+            title="No meal preps yet"
+            description="Plan a full week of prep-ahead meals. AI tracks macros and helps you hit your fitness goals."
+            action={{ label: "Plan first week", href: "/meal-prep/new" }}
+          />
+        ) : (
+          <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-4">
+            {mealPreps.map((mp) => (
+              <MealPrepCard key={mp.id} mealPrep={mp} />
             ))}
           </div>
         )}

--- a/recipe-app/app/api/chat/meal-prep/route.ts
+++ b/recipe-app/app/api/chat/meal-prep/route.ts
@@ -1,0 +1,56 @@
+import { getProvider } from "@/lib/ai/registry"
+import { buildMealPrepPlanningPrompt } from "@/lib/ai/prompts/meal-prep-planning"
+import type { Message } from "@/types/message"
+import type { ExistingRecipeSummaryForPrep } from "@/lib/ai/prompts/meal-prep-planning"
+
+export const runtime = "nodejs"
+
+const MAX_CONTEXT_MESSAGES = 20
+
+export async function POST(request: Request) {
+  try {
+    const body = await request.json() as {
+      messages: Message[]
+      providerId: string
+      modelId: string
+      existingRecipes?: ExistingRecipeSummaryForPrep[]
+    }
+
+    const { messages, providerId, modelId, existingRecipes = [] } = body
+
+    if (!messages || !providerId || !modelId) {
+      return new Response("Missing required fields", { status: 400 })
+    }
+
+    const provider = getProvider(providerId)
+    const systemPrompt = buildMealPrepPlanningPrompt(existingRecipes)
+    const contextMessages = messages.slice(-MAX_CONTEXT_MESSAGES)
+
+    const encoder = new TextEncoder()
+    const stream = new ReadableStream({
+      async start(controller) {
+        try {
+          for await (const chunk of provider.chat(contextMessages, systemPrompt, modelId)) {
+            controller.enqueue(encoder.encode(chunk))
+          }
+        } catch (err) {
+          const msg = err instanceof Error ? err.message : "Unknown error"
+          controller.enqueue(encoder.encode(`\n\n[Error: ${msg}]`))
+        } finally {
+          controller.close()
+        }
+      },
+    })
+
+    return new Response(stream, {
+      headers: {
+        "Content-Type": "text/plain; charset=utf-8",
+        "Transfer-Encoding": "chunked",
+        "X-Content-Type-Options": "nosniff",
+      },
+    })
+  } catch (err) {
+    const msg = err instanceof Error ? err.message : "Unknown error"
+    return new Response(msg, { status: 500 })
+  }
+}

--- a/recipe-app/app/meal-prep/MealPrepListClient.tsx
+++ b/recipe-app/app/meal-prep/MealPrepListClient.tsx
@@ -1,0 +1,51 @@
+"use client"
+
+import Link from "next/link"
+import { Plus, Dumbbell } from "lucide-react"
+import { useMealPreps } from "@/lib/hooks/useMealPreps"
+import { MealPrepCard } from "@/components/meal-prep/MealPrepCard"
+import { EmptyState } from "@/components/layout/EmptyState"
+
+export function MealPrepListClient() {
+  const mealPreps = useMealPreps()
+
+  return (
+    <div className="max-w-6xl mx-auto px-4 py-8">
+      <div className="flex items-center justify-between mb-5">
+        <h1 className="text-xl font-bold" style={{ color: "var(--color-foreground)" }}>
+          Meal Prep
+        </h1>
+        <Link
+          href="/meal-prep/new"
+          className="flex items-center gap-1.5 px-3 py-1.5 rounded-lg text-sm font-medium transition-colors"
+          style={{ color: "#065F46", backgroundColor: "#ECFDF5" }}
+        >
+          <Plus size={14} />
+          New Prep
+        </Link>
+      </div>
+
+      {mealPreps === undefined ? (
+        <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-4">
+          {[1, 2, 3].map((i) => (
+            <div key={i} className="h-28 rounded-2xl animate-pulse"
+              style={{ backgroundColor: "var(--color-muted)" }} />
+          ))}
+        </div>
+      ) : mealPreps.length === 0 ? (
+        <EmptyState
+          icon={Dumbbell}
+          title="No meal preps yet"
+          description="Plan a full week of prep-ahead meals. AI tracks macros and helps you hit your fitness goals."
+          action={{ label: "Plan first week", href: "/meal-prep/new" }}
+        />
+      ) : (
+        <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-4">
+          {mealPreps.map((mp) => (
+            <MealPrepCard key={mp.id} mealPrep={mp} />
+          ))}
+        </div>
+      )}
+    </div>
+  )
+}

--- a/recipe-app/app/meal-prep/[id]/MealPrepDetailClient.tsx
+++ b/recipe-app/app/meal-prep/[id]/MealPrepDetailClient.tsx
@@ -1,0 +1,181 @@
+"use client"
+
+import { useEffect, useMemo, useState } from "react"
+import { ArrowLeft } from "lucide-react"
+import Link from "next/link"
+import { useMealPrep } from "@/lib/hooks/useMealPreps"
+import { useRecipes } from "@/lib/hooks/useRecipes"
+import { useMealPrepChat } from "@/lib/hooks/useMealPrepChat"
+import { setMealPrepConversations } from "@/lib/db/meal-preps"
+import { ChatPanel } from "@/components/chat/ChatPanel"
+import { MacroSummary } from "@/components/meal-prep/MacroSummary"
+import { MealPrepRecipeList } from "@/components/meal-prep/MealPrepRecipeList"
+import type { Recipe } from "@/types/recipe"
+
+interface MealPrepDetailClientProps {
+  id: string
+}
+
+export function MealPrepDetailClient({ id }: MealPrepDetailClientProps) {
+  const mealPrep = useMealPrep(id)
+  const allRecipes = useRecipes()
+  const [mobileTab, setMobileTab] = useState<"overview" | "chat">("overview")
+
+  const recipesMap = useMemo<Record<string, Recipe>>(() => {
+    const map: Record<string, Recipe> = {}
+    for (const r of allRecipes ?? []) map[r.id] = r
+    return map
+  }, [allRecipes])
+
+  const existingRecipes = (allRecipes ?? []).map((r) => ({
+    id: r.id,
+    title: r.title,
+    tags: r.tags,
+    servings: r.servings,
+    macros: r.macros,
+  }))
+
+  const {
+    messages,
+    setMessages,
+    isStreaming,
+    streamingContent,
+    error,
+    send,
+    abort,
+    providerConfig,
+    setProviderConfig,
+  } = useMealPrepChat({
+    existingRecipes,
+    onMessagesChange: async (msgs) => {
+      if (mealPrep) {
+        await setMealPrepConversations(mealPrep.id, msgs)
+      }
+    },
+  })
+
+  useEffect(() => {
+    if (mealPrep && mealPrep.conversations.length > 0 && messages.length === 0) {
+      setMessages(mealPrep.conversations)
+    }
+  // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [mealPrep?.id])
+
+  if (mealPrep === undefined) {
+    return (
+      <div className="flex items-center justify-center h-[calc(100vh-56px)]">
+        <div className="w-8 h-8 rounded-full border-2 border-t-transparent animate-spin"
+          style={{ borderColor: "var(--color-border)", borderTopColor: "#059669" }} />
+      </div>
+    )
+  }
+
+  if (!mealPrep) {
+    return (
+      <div className="flex flex-col items-center justify-center h-[calc(100vh-56px)] gap-4">
+        <p style={{ color: "var(--color-muted-foreground)" }}>Meal prep not found.</p>
+        <Link href="/" className="text-sm font-medium" style={{ color: "#059669" }}>
+          Back to dashboard
+        </Link>
+      </div>
+    )
+  }
+
+  // Build macro entries from recipe refs that have macros
+  const macroEntries = mealPrep.recipeRefs
+    .map((ref) => {
+      const recipe = recipesMap[ref.recipeId]
+      if (!recipe?.macros) return null
+      return {
+        calories: recipe.macros.calories,
+        protein: recipe.macros.protein,
+        carbs: recipe.macros.carbs,
+        fat: recipe.macros.fat,
+        fiber: recipe.macros.fiber,
+        servingsPerWeek: ref.servingsPerWeek,
+      }
+    })
+    .filter((e): e is NonNullable<typeof e> => e !== null)
+
+  return (
+    <div className="flex flex-col h-[calc(100vh-56px)]">
+      {/* Page header */}
+      <div className="flex items-center gap-3 px-4 py-3 border-b shrink-0"
+        style={{ borderColor: "var(--color-border)", backgroundColor: "var(--color-card)" }}>
+        <Link href="/" className="p-1.5 rounded-lg transition-colors hover:bg-muted"
+          style={{ color: "var(--color-muted-foreground)" }}>
+          <ArrowLeft size={16} />
+        </Link>
+        <div className="flex-1 min-w-0">
+          <h1 className="text-sm font-semibold truncate" style={{ color: "var(--color-foreground)" }}>
+            {mealPrep.title}
+          </h1>
+          {mealPrep.description && (
+            <p className="text-xs truncate" style={{ color: "var(--color-muted-foreground)" }}>
+              {mealPrep.description}
+            </p>
+          )}
+        </div>
+      </div>
+
+      {/* Mobile tab switcher */}
+      <div className="flex border-b shrink-0 md:hidden" style={{ borderColor: "var(--color-border)" }}>
+        {([["overview", "Overview"], ["chat", "Chat"]] as const).map(([tab, label]) => (
+          <button
+            key={tab}
+            onClick={() => setMobileTab(tab)}
+            className="flex-1 py-2.5 text-sm font-medium transition-colors"
+            style={mobileTab === tab ? {
+              color: "#059669",
+              borderBottom: "2px solid #059669",
+            } : { color: "var(--color-muted-foreground)" }}
+          >
+            {label}
+          </button>
+        ))}
+      </div>
+
+      {/* Split: overview + chat */}
+      <div className="flex-1 flex overflow-hidden">
+        {/* Overview: macros + recipe list */}
+        <div className={mobileTab === "overview" ? "flex flex-col flex-1 overflow-y-auto p-4 gap-6" : "hidden md:flex md:flex-col md:flex-1 md:overflow-y-auto md:p-6 md:gap-6"}>
+          {macroEntries.length > 0 && (
+            <MacroSummary entries={macroEntries} />
+          )}
+          {macroEntries.length === 0 && mealPrep.recipeRefs.length > 0 && (
+            <div className="rounded-2xl border p-4 text-sm"
+              style={{ borderColor: "var(--color-border)", color: "var(--color-muted-foreground)" }}>
+              Macro data will appear here once recipes are generated.
+            </div>
+          )}
+          <div>
+            <h2 className="text-sm font-semibold uppercase tracking-wide mb-4"
+              style={{ color: "var(--color-muted-foreground)" }}>
+              Weekly Dishes
+            </h2>
+            <MealPrepRecipeList recipeRefs={mealPrep.recipeRefs} recipes={recipesMap} />
+          </div>
+        </div>
+
+        {/* Chat */}
+        <div
+          className={mobileTab === "chat" ? "flex flex-col flex-1 overflow-hidden md:w-96 md:flex-none md:border-l" : "hidden md:flex md:flex-col md:w-96 md:shrink-0 md:border-l md:overflow-hidden"}
+          style={{ borderColor: "var(--color-border)" }}
+        >
+          <ChatPanel
+            messages={messages}
+            isStreaming={isStreaming}
+            streamingContent={streamingContent}
+            error={error}
+            onSend={send}
+            onAbort={abort}
+            providerConfig={providerConfig}
+            onProviderConfigChange={setProviderConfig}
+            placeholder="Ask about this meal prep plan…"
+            className="h-full"
+          />
+        </div>
+      </div>
+    </div>
+  )
+}

--- a/recipe-app/app/meal-prep/[id]/MealPrepDetailClient.tsx
+++ b/recipe-app/app/meal-prep/[id]/MealPrepDetailClient.tsx
@@ -85,13 +85,14 @@ export function MealPrepDetailClient({ id }: MealPrepDetailClientProps) {
   const macroEntries = mealPrep.recipeRefs
     .map((ref) => {
       const recipe = recipesMap[ref.recipeId]
-      if (!recipe?.macros) return null
+      const macros = recipe?.macros ?? ref.estimatedMacros
+      if (!macros) return null
       return {
-        calories: recipe.macros.calories,
-        protein: recipe.macros.protein,
-        carbs: recipe.macros.carbs,
-        fat: recipe.macros.fat,
-        fiber: recipe.macros.fiber,
+        calories: macros.calories,
+        protein: macros.protein,
+        carbs: macros.carbs,
+        fat: macros.fat,
+        fiber: recipe?.macros?.fiber,
         servingsPerWeek: ref.servingsPerWeek,
       }
     })
@@ -145,7 +146,7 @@ export function MealPrepDetailClient({ id }: MealPrepDetailClientProps) {
           {macroEntries.length === 0 && mealPrep.recipeRefs.length > 0 && (
             <div className="rounded-2xl border p-4 text-sm"
               style={{ borderColor: "var(--color-border)", color: "var(--color-muted-foreground)" }}>
-              Macro data will appear here once recipes are generated.
+              No macro data available yet. Open a recipe and let the AI generate it to populate macros.
             </div>
           )}
           <div>

--- a/recipe-app/app/meal-prep/[id]/page.tsx
+++ b/recipe-app/app/meal-prep/[id]/page.tsx
@@ -1,0 +1,10 @@
+import { MealPrepDetailClient } from "./MealPrepDetailClient"
+
+export default async function MealPrepDetailPage({
+  params,
+}: {
+  params: Promise<{ id: string }>
+}) {
+  const { id } = await params
+  return <MealPrepDetailClient id={id} />
+}

--- a/recipe-app/app/meal-prep/new/NewMealPrepClient.tsx
+++ b/recipe-app/app/meal-prep/new/NewMealPrepClient.tsx
@@ -60,7 +60,7 @@ export function NewMealPrepClient() {
       const resolvedRefs = await Promise.all(
         activePlan.suggestions.map(async (s) => {
           if (s.recipeId) {
-            return { recipeId: s.recipeId, servingsPerWeek: s.servingsPerWeek }
+            return { recipeId: s.recipeId, servingsPerWeek: s.servingsPerWeek, estimatedMacros: s.estimatedMacros }
           }
           const stub = await createRecipe({
             title: s.title,
@@ -76,7 +76,7 @@ export function NewMealPrepClient() {
             providerId: providerConfig.providerId,
           })
           newStubs.push({ recipeId: stub.id, title: s.title })
-          return { recipeId: stub.id, servingsPerWeek: s.servingsPerWeek }
+          return { recipeId: stub.id, servingsPerWeek: s.servingsPerWeek, estimatedMacros: s.estimatedMacros }
         })
       )
 

--- a/recipe-app/app/meal-prep/new/NewMealPrepClient.tsx
+++ b/recipe-app/app/meal-prep/new/NewMealPrepClient.tsx
@@ -1,0 +1,324 @@
+"use client"
+
+import { useEffect, useState } from "react"
+import { ArrowLeft, Plus, Check, Dumbbell, X } from "lucide-react"
+import Link from "next/link"
+import { useRouter } from "next/navigation"
+import { ChatPanel } from "@/components/chat/ChatPanel"
+import { useMealPrepChat, type ParsedMealPrepPlan } from "@/lib/hooks/useMealPrepChat"
+import { useRecipes } from "@/lib/hooks/useRecipes"
+import { createMealPrep } from "@/lib/db/meal-preps"
+import { createRecipe, updateRecipe } from "@/lib/db/recipes"
+import { extractRecipeJSON } from "@/lib/utils/recipe-parser"
+import { toast } from "sonner"
+import type { Message } from "@/types/message"
+
+export function NewMealPrepClient() {
+  const router = useRouter()
+  const recipes = useRecipes()
+  const [saving, setSaving] = useState(false)
+  const [savedPlan, setSavedPlan] = useState<ParsedMealPrepPlan | null>(null)
+  const [showPlanSheet, setShowPlanSheet] = useState(false)
+
+  const existingRecipes = (recipes ?? []).map((r) => ({
+    id: r.id,
+    title: r.title,
+    tags: r.tags,
+    servings: r.servings,
+    macros: r.macros,
+  }))
+
+  const {
+    messages,
+    isStreaming,
+    streamingContent,
+    error,
+    send,
+    abort,
+    pendingMealPrepPlan,
+    clearPendingMealPrepPlan,
+    providerConfig,
+    setProviderConfig,
+  } = useMealPrepChat({ existingRecipes })
+
+  useEffect(() => {
+    const stored = localStorage.getItem("preferred-model")
+    if (stored) {
+      const [providerId, modelId] = stored.split("::")
+      if (providerId && modelId) setProviderConfig({ providerId, modelId })
+    }
+  }, [setProviderConfig])
+
+  const activePlan = savedPlan ?? pendingMealPrepPlan
+
+  async function handleSaveMealPrep() {
+    if (!activePlan) return
+    setSaving(true)
+    try {
+      const newStubs: Array<{ recipeId: string; title: string }> = []
+
+      const resolvedRefs = await Promise.all(
+        activePlan.suggestions.map(async (s) => {
+          if (s.recipeId) {
+            return { recipeId: s.recipeId, servingsPerWeek: s.servingsPerWeek }
+          }
+          const stub = await createRecipe({
+            title: s.title,
+            description: "",
+            servings: 0,
+            prepTime: 0,
+            cookTime: 0,
+            tags: [],
+            ingredients: [],
+            steps: [],
+            conversations: [],
+            modelId: providerConfig.modelId,
+            providerId: providerConfig.providerId,
+          })
+          newStubs.push({ recipeId: stub.id, title: s.title })
+          return { recipeId: stub.id, servingsPerWeek: s.servingsPerWeek }
+        })
+      )
+
+      const mealPrep = await createMealPrep({
+        title: activePlan.title,
+        description: activePlan.description,
+        recipeRefs: resolvedRefs,
+        conversations: messages,
+        modelId: providerConfig.modelId,
+        providerId: providerConfig.providerId,
+      })
+
+      for (const { recipeId, title } of newStubs) {
+        generateRecipe(recipeId, title, providerConfig.providerId, providerConfig.modelId)
+          .catch(() => {})
+      }
+
+      toast.success(`Meal prep saved! Generating ${newStubs.length} recipe${newStubs.length !== 1 ? "s" : ""} in the background…`)
+      router.push(`/meal-prep/${mealPrep.id}`)
+    } catch (err) {
+      toast.error(err instanceof Error ? err.message : "Save failed")
+    } finally {
+      setSaving(false)
+    }
+  }
+
+  return (
+    <div className="flex flex-col h-[calc(100vh-56px)]">
+      {/* Page header */}
+      <div className="flex items-center gap-3 px-4 py-3 border-b shrink-0"
+        style={{ borderColor: "var(--color-border)", backgroundColor: "var(--color-card)" }}>
+        <Link href="/" className="p-1.5 rounded-lg transition-colors hover:bg-muted"
+          style={{ color: "var(--color-muted-foreground)" }}>
+          <ArrowLeft size={16} />
+        </Link>
+        <div>
+          <h1 className="text-sm font-semibold" style={{ color: "var(--color-foreground)" }}>
+            New Meal Prep
+          </h1>
+          <p className="text-xs" style={{ color: "var(--color-muted-foreground)" }}>
+            Describe your fitness goals and AI will plan a full week of meal prep.
+          </p>
+        </div>
+      </div>
+
+      <div className="flex-1 flex overflow-hidden">
+        {/* Chat */}
+        <div className="flex-1 overflow-hidden">
+          <ChatPanel
+            messages={messages}
+            isStreaming={isStreaming}
+            streamingContent={streamingContent}
+            error={error}
+            onSend={send}
+            onAbort={abort}
+            providerConfig={providerConfig}
+            onProviderConfigChange={setProviderConfig}
+            placeholder="Describe your fitness goals, macro targets, dietary preferences…"
+            className="h-full"
+          />
+        </div>
+
+        {/* Meal prep plan preview — desktop sidebar */}
+        {activePlan && (
+          <div className="hidden md:flex md:flex-col w-80 shrink-0 border-l overflow-y-auto p-4"
+            style={{ borderColor: "var(--color-border)", backgroundColor: "var(--color-card)" }}>
+            <PrepPlanContent
+              plan={activePlan}
+              saving={saving}
+              onClear={clearPendingMealPrepPlan}
+              onSave={handleSaveMealPrep}
+            />
+          </div>
+        )}
+      </div>
+
+      {/* Mobile: floating "View Plan" button */}
+      {activePlan && (
+        <button
+          onClick={() => setShowPlanSheet(true)}
+          className="md:hidden fixed bottom-20 right-4 flex items-center gap-2 px-4 py-2.5 rounded-full text-sm font-semibold text-white shadow-lg z-30 transition-opacity hover:opacity-90"
+          style={{ backgroundColor: "#059669" }}
+        >
+          <Dumbbell size={15} />
+          View Plan ({activePlan.suggestions.length})
+        </button>
+      )}
+
+      {/* Mobile: plan bottom sheet */}
+      {showPlanSheet && activePlan && (
+        <div
+          className="md:hidden fixed inset-0 z-50 flex flex-col justify-end"
+          style={{ backgroundColor: "rgba(0,0,0,0.4)" }}
+          onClick={() => setShowPlanSheet(false)}
+        >
+          <div
+            className="rounded-t-2xl max-h-[80vh] overflow-y-auto p-4"
+            style={{ backgroundColor: "var(--color-card)" }}
+            onClick={(e) => e.stopPropagation()}
+          >
+            <div className="flex items-center justify-between mb-4">
+              <span className="text-sm font-semibold" style={{ color: "var(--color-foreground)" }}>
+                Meal Prep Plan
+              </span>
+              <button
+                onClick={() => setShowPlanSheet(false)}
+                className="p-1.5 rounded-lg"
+                style={{ color: "var(--color-muted-foreground)" }}
+              >
+                <X size={16} />
+              </button>
+            </div>
+            <PrepPlanContent
+              plan={activePlan}
+              saving={saving}
+              onClear={() => { clearPendingMealPrepPlan(); setShowPlanSheet(false) }}
+              onSave={handleSaveMealPrep}
+            />
+          </div>
+        </div>
+      )}
+    </div>
+  )
+}
+
+interface PrepPlanContentProps {
+  plan: ParsedMealPrepPlan
+  saving: boolean
+  onClear: () => void
+  onSave: () => void
+}
+
+function PrepPlanContent({ plan, saving, onClear, onSave }: PrepPlanContentProps) {
+  return (
+    <>
+      <div className="flex items-start justify-between gap-2 mb-4">
+        <div>
+          <h2 className="text-sm font-semibold" style={{ color: "var(--color-foreground)" }}>
+            {plan.title}
+          </h2>
+          <p className="text-xs mt-0.5" style={{ color: "var(--color-muted-foreground)" }}>
+            {plan.description}
+          </p>
+        </div>
+        <button
+          onClick={onClear}
+          className="text-xs px-2 py-1 rounded-md transition-colors hover:bg-muted"
+          style={{ color: "var(--color-muted-foreground)" }}
+        >
+          Clear
+        </button>
+      </div>
+
+      <div className="space-y-2 mb-4">
+        {plan.suggestions.map((s, i) => (
+          <div key={i} className="flex items-start gap-3 p-3 rounded-xl border"
+            style={{ borderColor: "var(--color-border)", backgroundColor: "var(--color-background)" }}>
+            <div className="flex-1 min-w-0">
+              <span className="text-xs font-medium"
+                style={{ color: "var(--color-muted-foreground)" }}>
+                {s.servingsPerWeek}× per week
+              </span>
+              <p className="text-sm font-medium mt-0.5 truncate"
+                style={{ color: "var(--color-foreground)" }}>
+                {s.title}
+              </p>
+              {s.estimatedMacros && (
+                <p className="text-xs mt-0.5" style={{ color: "var(--color-muted-foreground)" }}>
+                  ~{s.estimatedMacros.calories} kcal · {s.estimatedMacros.protein}g P · {s.estimatedMacros.carbs}g C · {s.estimatedMacros.fat}g F
+                </p>
+              )}
+              {s.recipeId && (
+                <p className="text-xs mt-0.5" style={{ color: "#059669" }}>
+                  Using saved recipe
+                </p>
+              )}
+            </div>
+            {s.recipeId && (
+              <Check size={14} className="shrink-0 mt-0.5" style={{ color: "#059669" }} />
+            )}
+          </div>
+        ))}
+      </div>
+
+      <button
+        onClick={onSave}
+        disabled={saving}
+        className="w-full flex items-center justify-center gap-2 py-2.5 rounded-xl text-sm font-semibold text-white transition-opacity disabled:opacity-60 hover:opacity-90"
+        style={{ backgroundColor: "#059669" }}
+      >
+        <Plus size={15} />
+        {saving ? "Saving…" : "Save Meal Prep"}
+      </button>
+    </>
+  )
+}
+
+async function generateRecipe(
+  recipeId: string,
+  title: string,
+  providerId: string,
+  modelId: string,
+): Promise<void> {
+  const userMessage: Message = {
+    id: crypto.randomUUID(),
+    role: "user",
+    content: `Please create a complete recipe for: ${title}`,
+    timestamp: Date.now(),
+  }
+
+  const res = await fetch("/api/chat/recipe", {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify({ messages: [userMessage], providerId, modelId, recipe: null }),
+  })
+
+  if (!res.ok || !res.body) return
+
+  const reader = res.body.getReader()
+  const decoder = new TextDecoder()
+  let fullText = ""
+
+  while (true) {
+    const { done, value } = await reader.read()
+    if (done) break
+    fullText += decoder.decode(value, { stream: true })
+  }
+
+  const parsed = extractRecipeJSON(fullText)
+  if (!parsed || parsed.type !== "recipe") return
+
+  const assistantMessage: Message = {
+    id: crypto.randomUUID(),
+    role: "assistant",
+    content: fullText,
+    timestamp: Date.now(),
+  }
+
+  await updateRecipe(recipeId, {
+    ...parsed.data,
+    conversations: [userMessage, assistantMessage],
+    modelId,
+    providerId,
+  })
+}

--- a/recipe-app/app/meal-prep/new/page.tsx
+++ b/recipe-app/app/meal-prep/new/page.tsx
@@ -1,0 +1,5 @@
+import { NewMealPrepClient } from "./NewMealPrepClient"
+
+export default function NewMealPrepPage() {
+  return <NewMealPrepClient />
+}

--- a/recipe-app/app/meal-prep/page.tsx
+++ b/recipe-app/app/meal-prep/page.tsx
@@ -1,0 +1,5 @@
+import { MealPrepListClient } from "./MealPrepListClient"
+
+export default function MealPrepPage() {
+  return <MealPrepListClient />
+}

--- a/recipe-app/components/chat/ChatMessage.tsx
+++ b/recipe-app/components/chat/ChatMessage.tsx
@@ -64,6 +64,7 @@ function splitStreamingContent(content: string): {
     type === "recipe" ? "Building recipe…"
     : type === "recipe_update" ? "Updating recipe…"
     : type === "meal_plan" ? "Building meal plan…"
+    : type === "meal_prep_plan" ? "Building meal prep plan…"
     : "Generating…"
 
   return { text: before, isGenerating: true, generatingLabel: label }

--- a/recipe-app/components/layout/AppHeader.tsx
+++ b/recipe-app/components/layout/AppHeader.tsx
@@ -2,7 +2,7 @@
 
 import Link from "next/link"
 import { usePathname } from "next/navigation"
-import { ChefHat, BookOpen, Utensils, Plus } from "lucide-react"
+import { ChefHat, BookOpen, Utensils, Dumbbell, Plus } from "lucide-react"
 import { cn } from "@/lib/utils/cn"
 
 export function AppHeader() {
@@ -11,6 +11,7 @@ export function AppHeader() {
   const navLinks = [
     { href: "/", label: "Recipes", icon: BookOpen, match: /^\/\$|^\/recipes/ },
     { href: "/meals", label: "Meals", icon: Utensils, match: /^\/meals/ },
+    { href: "/meal-prep", label: "Prep", icon: Dumbbell, match: /^\/meal-prep/ },
   ]
 
   return (

--- a/recipe-app/components/meal-prep/MacroSummary.tsx
+++ b/recipe-app/components/meal-prep/MacroSummary.tsx
@@ -1,0 +1,115 @@
+"use client"
+
+interface MacroEntry {
+  calories: number
+  protein: number
+  carbs: number
+  fat: number
+  fiber?: number
+  servingsPerWeek: number
+}
+
+interface MacroSummaryProps {
+  entries: MacroEntry[]
+}
+
+function calcTotals(entries: MacroEntry[]) {
+  return entries.reduce(
+    (acc, e) => ({
+      calories: acc.calories + e.calories * e.servingsPerWeek,
+      protein: acc.protein + e.protein * e.servingsPerWeek,
+      carbs: acc.carbs + e.carbs * e.servingsPerWeek,
+      fat: acc.fat + e.fat * e.servingsPerWeek,
+      fiber: acc.fiber + (e.fiber ?? 0) * e.servingsPerWeek,
+    }),
+    { calories: 0, protein: 0, carbs: 0, fat: 0, fiber: 0 }
+  )
+}
+
+export function MacroSummary({ entries }: MacroSummaryProps) {
+  if (entries.length === 0) return null
+
+  const weekly = calcTotals(entries)
+  const daily = {
+    calories: Math.round(weekly.calories / 7),
+    protein: Math.round(weekly.protein / 7),
+    carbs: Math.round(weekly.carbs / 7),
+    fat: Math.round(weekly.fat / 7),
+    fiber: Math.round(weekly.fiber / 7),
+  }
+
+  const proteinCals = weekly.protein * 4
+  const carbsCals = weekly.carbs * 4
+  const fatCals = weekly.fat * 9
+  const totalMacroCals = proteinCals + carbsCals + fatCals || 1
+  const proteinPct = Math.round((proteinCals / totalMacroCals) * 100)
+  const carbsPct = Math.round((carbsCals / totalMacroCals) * 100)
+  const fatPct = 100 - proteinPct - carbsPct
+
+  const tiles = [
+    { label: "Calories", value: daily.calories.toLocaleString(), unit: "kcal/day", accent: "#6366F1" },
+    { label: "Protein", value: daily.protein, unit: "g/day", accent: "#059669" },
+    { label: "Carbs", value: daily.carbs, unit: "g/day", accent: "#D97706" },
+    { label: "Fat", value: daily.fat, unit: "g/day", accent: "#DC2626" },
+  ]
+
+  return (
+    <div className="rounded-2xl border p-4"
+      style={{ borderColor: "var(--color-border)", backgroundColor: "var(--color-card)" }}>
+      <h3 className="text-xs font-semibold uppercase tracking-wide mb-3"
+        style={{ color: "var(--color-muted-foreground)" }}>
+        Daily Averages
+      </h3>
+
+      <div className="grid grid-cols-2 sm:grid-cols-4 gap-3 mb-4">
+        {tiles.map((t) => (
+          <div key={t.label} className="rounded-xl p-3"
+            style={{ backgroundColor: "var(--color-background)" }}>
+            <p className="text-xs mb-1" style={{ color: "var(--color-muted-foreground)" }}>{t.label}</p>
+            <p className="text-lg font-bold" style={{ color: t.accent }}>{t.value}</p>
+            <p className="text-xs" style={{ color: "var(--color-muted-foreground)" }}>{t.unit}</p>
+          </div>
+        ))}
+      </div>
+
+      {/* P / C / F ratio bar */}
+      <div className="mb-2">
+        <p className="text-xs mb-1.5" style={{ color: "var(--color-muted-foreground)" }}>
+          Macro ratio &nbsp;
+          <span style={{ color: "#059669" }}>P {proteinPct}%</span>
+          {" · "}
+          <span style={{ color: "#D97706" }}>C {carbsPct}%</span>
+          {" · "}
+          <span style={{ color: "#DC2626" }}>F {fatPct}%</span>
+        </p>
+        <div className="flex rounded-full overflow-hidden h-2">
+          <div style={{ width: `${proteinPct}%`, backgroundColor: "#059669" }} />
+          <div style={{ width: `${carbsPct}%`, backgroundColor: "#D97706" }} />
+          <div style={{ width: `${fatPct}%`, backgroundColor: "#DC2626" }} />
+        </div>
+      </div>
+
+      {/* Weekly totals footer */}
+      <div className="pt-3 mt-3 border-t flex flex-wrap gap-x-4 gap-y-1"
+        style={{ borderColor: "var(--color-border)" }}>
+        <span className="text-xs" style={{ color: "var(--color-muted-foreground)" }}>
+          Weekly: <strong style={{ color: "var(--color-foreground)" }}>{weekly.calories.toLocaleString()} kcal</strong>
+        </span>
+        <span className="text-xs" style={{ color: "var(--color-muted-foreground)" }}>
+          <strong style={{ color: "var(--color-foreground)" }}>{Math.round(weekly.protein)}g</strong> protein
+        </span>
+        <span className="text-xs" style={{ color: "var(--color-muted-foreground)" }}>
+          <strong style={{ color: "var(--color-foreground)" }}>{Math.round(weekly.carbs)}g</strong> carbs
+        </span>
+        <span className="text-xs" style={{ color: "var(--color-muted-foreground)" }}>
+          <strong style={{ color: "var(--color-foreground)" }}>{Math.round(weekly.fat)}g</strong> fat
+        </span>
+        {weekly.fiber > 0 && (
+          <span className="text-xs" style={{ color: "var(--color-muted-foreground)" }}>
+            <strong style={{ color: "var(--color-foreground)" }}>{Math.round(weekly.fiber)}g</strong> fiber
+          </span>
+        )}
+      </div>
+    </div>
+  )
+}

--- a/recipe-app/components/meal-prep/MealPrepCard.tsx
+++ b/recipe-app/components/meal-prep/MealPrepCard.tsx
@@ -1,0 +1,47 @@
+"use client"
+
+import Link from "next/link"
+import { Dumbbell } from "lucide-react"
+import type { MealPrep } from "@/types/meal-prep"
+
+interface MealPrepCardProps {
+  mealPrep: MealPrep
+}
+
+export function MealPrepCard({ mealPrep }: MealPrepCardProps) {
+  const recipeCount = mealPrep.recipeRefs.length
+  const totalServings = mealPrep.recipeRefs.reduce((s, r) => s + r.servingsPerWeek, 0)
+
+  return (
+    <Link
+      href={`/meal-prep/${mealPrep.id}`}
+      className="block rounded-2xl border p-4 transition-colors hover:bg-muted/50"
+      style={{ borderColor: "var(--color-border)", backgroundColor: "var(--color-card)" }}
+    >
+      <div className="flex items-start gap-3">
+        <div className="p-2 rounded-lg shrink-0"
+          style={{ backgroundColor: "#ECFDF5", color: "#059669" }}>
+          <Dumbbell size={16} />
+        </div>
+        <div className="flex-1 min-w-0">
+          <p className="text-sm font-semibold truncate" style={{ color: "var(--color-foreground)" }}>
+            {mealPrep.title}
+          </p>
+          {mealPrep.description && (
+            <p className="text-xs mt-0.5 line-clamp-2" style={{ color: "var(--color-muted-foreground)" }}>
+              {mealPrep.description}
+            </p>
+          )}
+          <div className="flex items-center gap-3 mt-2">
+            <span className="text-xs" style={{ color: "var(--color-muted-foreground)" }}>
+              {recipeCount} dish{recipeCount !== 1 ? "es" : ""}
+            </span>
+            <span className="text-xs" style={{ color: "var(--color-muted-foreground)" }}>
+              {totalServings} servings/week
+            </span>
+          </div>
+        </div>
+      </div>
+    </Link>
+  )
+}

--- a/recipe-app/components/meal-prep/MealPrepRecipeList.tsx
+++ b/recipe-app/components/meal-prep/MealPrepRecipeList.tsx
@@ -1,0 +1,110 @@
+"use client"
+
+import Link from "next/link"
+import { Dumbbell, ExternalLink, Sparkles } from "lucide-react"
+import type { MealPrepRecipeRef } from "@/types/meal-prep"
+import type { Recipe } from "@/types/recipe"
+
+interface MealPrepRecipeListProps {
+  recipeRefs: MealPrepRecipeRef[]
+  recipes: Record<string, Recipe>
+}
+
+export function MealPrepRecipeList({ recipeRefs, recipes }: MealPrepRecipeListProps) {
+  if (recipeRefs.length === 0) {
+    return (
+      <div className="text-sm py-6 text-center" style={{ color: "var(--color-muted-foreground)" }}>
+        No recipes added yet. Chat with AI to plan your meal prep week.
+      </div>
+    )
+  }
+
+  return (
+    <div className="space-y-2">
+      {recipeRefs.map((ref, i) => {
+        const recipe = recipes[ref.recipeId]
+        const isStub = recipe && recipe.ingredients.length === 0 && recipe.steps.length === 0
+        const macros = recipe?.macros
+
+        return (
+          <div key={i} className="flex items-start gap-3 p-3 rounded-xl border"
+            style={{
+              borderColor: isStub ? "#A7F3D0" : "var(--color-border)",
+              backgroundColor: isStub ? "#ECFDF5" : "var(--color-card)",
+            }}>
+            <div className="w-8 h-8 rounded-lg flex items-center justify-center shrink-0 mt-0.5"
+              style={{ backgroundColor: "#ECFDF5", color: "#059669" }}>
+              <Dumbbell size={15} />
+            </div>
+
+            <div className="flex-1 min-w-0">
+              <div className="flex items-center gap-2 flex-wrap">
+                <span className="text-xs font-medium px-2 py-0.5 rounded-full"
+                  style={{ backgroundColor: "#ECFDF5", color: "#059669" }}>
+                  {ref.servingsPerWeek}×/week
+                </span>
+                {isStub && (
+                  <span className="text-xs font-medium" style={{ color: "#059669" }}>
+                    Not generated yet
+                  </span>
+                )}
+              </div>
+
+              {recipe ? (
+                <p className="text-sm font-medium mt-0.5 truncate"
+                  style={{ color: "var(--color-foreground)" }}>
+                  {recipe.title}
+                </p>
+              ) : (
+                <p className="text-sm mt-0.5" style={{ color: "var(--color-muted-foreground)" }}>
+                  Recipe not found
+                </p>
+              )}
+
+              {macros && (
+                <div className="flex flex-wrap gap-x-3 gap-y-0.5 mt-1">
+                  <span className="text-xs" style={{ color: "var(--color-muted-foreground)" }}>
+                    <strong style={{ color: "#6366F1" }}>{macros.calories}</strong> kcal
+                  </span>
+                  <span className="text-xs" style={{ color: "var(--color-muted-foreground)" }}>
+                    <strong style={{ color: "#059669" }}>{macros.protein}g</strong> protein
+                  </span>
+                  <span className="text-xs" style={{ color: "var(--color-muted-foreground)" }}>
+                    <strong style={{ color: "#D97706" }}>{macros.carbs}g</strong> carbs
+                  </span>
+                  <span className="text-xs" style={{ color: "var(--color-muted-foreground)" }}>
+                    <strong style={{ color: "#DC2626" }}>{macros.fat}g</strong> fat
+                  </span>
+                  <span className="text-xs" style={{ color: "var(--color-muted-foreground)" }}>
+                    per serving
+                  </span>
+                </div>
+              )}
+            </div>
+
+            {recipe && (
+              <Link
+                href={`/recipes/${ref.recipeId}`}
+                className="shrink-0 flex items-center gap-1 px-2.5 py-1.5 rounded-lg text-xs font-medium transition-colors mt-0.5"
+                style={isStub ? {
+                  backgroundColor: "#059669",
+                  color: "white",
+                } : {
+                  color: "var(--color-muted-foreground)",
+                }}
+                title={isStub ? "Generate recipe" : "View recipe"}
+                onClick={(e) => e.stopPropagation()}
+              >
+                {isStub ? (
+                  <><Sparkles size={12} /> Generate</>
+                ) : (
+                  <ExternalLink size={14} />
+                )}
+              </Link>
+            )}
+          </div>
+        )
+      })}
+    </div>
+  )
+}

--- a/recipe-app/lib/ai/prompts/meal-prep-planning.ts
+++ b/recipe-app/lib/ai/prompts/meal-prep-planning.ts
@@ -1,0 +1,69 @@
+export interface ExistingRecipeSummaryForPrep {
+  id: string
+  title: string
+  tags: string[]
+  servings: number
+  macros?: {
+    calories: number
+    protein: number
+    carbs: number
+    fat: number
+  }
+}
+
+export function buildMealPrepPlanningPrompt(existingRecipes: ExistingRecipeSummaryForPrep[]): string {
+  const recipesContext =
+    existingRecipes.length > 0
+      ? `\nUSER'S SAVED RECIPES (reference these by ID when they fit the plan):\n${JSON.stringify(existingRecipes)}\n`
+      : "\nThe user has no saved recipes yet.\n"
+
+  return `You are a fitness-focused meal prep assistant helping users plan a full week of prep-ahead meals to hit their nutrition goals.
+${recipesContext}
+YOUR JOB is to help the user choose WHICH dishes to batch-cook for the week — not to write full recipes.
+Do NOT write ingredient lists, cooking steps, or recipe instructions. That happens separately.
+
+CAPABILITIES:
+- Understand fitness goals (muscle gain, fat loss, maintenance, endurance)
+- Understand macros targets (protein, calories, carbs, fat)
+- Understand dietary restrictions and preferences
+- Suggest meal prep dishes that reheat well and can be portioned for the week
+- Reference the user's existing saved recipes by ID when they're a good fit
+- Estimate macros PER SERVING for each suggested dish
+- Recommend servingsPerWeek (how many times to eat that dish in a week)
+
+CONVERSATION:
+- Ask about fitness goals, macro targets, dietary restrictions, and prep preferences if not provided (1-2 questions at a time).
+- Once you have enough context, briefly describe the weekly plan (2-3 sentences), then output the JSON block below.
+- Do NOT write ingredient lists or cooking instructions — only dish names and macro estimates.
+
+REQUIRED OUTPUT FORMAT — always output this JSON block when proposing a meal prep plan:
+\`\`\`json
+{
+  "__type": "meal_prep_plan",
+  "title": "High-Protein Bulk Week",
+  "description": "7-day meal prep targeting ~2,800 cal/day with 200g protein for lean muscle building.",
+  "suggestions": [
+    {
+      "title": "Chicken & Brown Rice",
+      "servingsPerWeek": 7,
+      "recipeId": null,
+      "isNew": true,
+      "estimatedMacros": { "calories": 450, "protein": 45, "carbs": 40, "fat": 8 }
+    },
+    {
+      "title": "Greek Yogurt Parfait",
+      "servingsPerWeek": 7,
+      "recipeId": "abc123",
+      "isNew": false,
+      "estimatedMacros": { "calories": 280, "protein": 22, "carbs": 30, "fat": 6 }
+    }
+  ]
+}
+\`\`\`
+
+estimatedMacros are per serving (calories, protein g, carbs g, fat g).
+servingsPerWeek is how many times this dish will be eaten across the week (1–14).
+If referencing an existing saved recipe, use its exact ID. Otherwise set recipeId to null and isNew to true.
+
+After the JSON, tell the user to click "Save Meal Prep" to lock in the plan — then they can view the full macro breakdown and generate each new recipe.`
+}

--- a/recipe-app/lib/ai/prompts/recipe-creation.ts
+++ b/recipe-app/lib/ai/prompts/recipe-creation.ts
@@ -30,10 +30,11 @@ RECIPE JSON FORMAT (output exactly this structure when ready):
     { "order": 4, "instruction": "Cook pasta until al dente. Reserve 1 cup of pasta water before draining.", "duration": 10 },
     { "order": 5, "instruction": "Add hot pasta to the guanciale pan (off heat). Pour egg mixture over and toss quickly, adding pasta water a splash at a time to create a creamy sauce.", "duration": 3 },
     { "order": 6, "instruction": "Serve immediately topped with remaining pecorino and extra black pepper." }
-  ]
+  ],
+  "macros": { "calories": 620, "protein": 28, "carbs": 72, "fat": 24, "fiber": 3 }
 }
 \`\`\`
 
 After outputting the JSON, tell the user their recipe is ready to save by clicking "Save Recipe".
 
-IMPORTANT: prepTime and cookTime are integers in minutes. amounts are numbers. steps must have sequential order values starting at 1.`
+IMPORTANT: prepTime and cookTime are integers in minutes. amounts are numbers. steps must have sequential order values starting at 1. macros are always required and represent values PER SERVING (calories in kcal, protein/carbs/fat/fiber in grams). Estimate them as accurately as possible.`

--- a/recipe-app/lib/db/meal-preps.ts
+++ b/recipe-app/lib/db/meal-preps.ts
@@ -1,0 +1,42 @@
+import { getDB } from "./schema"
+import type { MealPrep, MealPrepCreate, MealPrepUpdate } from "@/types/meal-prep"
+import type { Message } from "@/types/message"
+
+export async function getAllMealPreps(): Promise<MealPrep[]> {
+  return getDB().mealPreps.orderBy("updatedAt").reverse().toArray()
+}
+
+export async function getMealPrepById(id: string): Promise<MealPrep | undefined> {
+  return getDB().mealPreps.get(id)
+}
+
+export async function createMealPrep(data: MealPrepCreate): Promise<MealPrep> {
+  const now = Date.now()
+  const mealPrep: MealPrep = {
+    ...data,
+    id: crypto.randomUUID(),
+    createdAt: now,
+    updatedAt: now,
+  }
+  await getDB().mealPreps.add(mealPrep)
+  return mealPrep
+}
+
+export async function updateMealPrep(id: string, data: MealPrepUpdate): Promise<void> {
+  await getDB().mealPreps.update(id, { ...data, updatedAt: Date.now() })
+}
+
+export async function deleteMealPrep(id: string): Promise<void> {
+  await getDB().mealPreps.delete(id)
+}
+
+export async function appendMessageToMealPrep(id: string, message: Message): Promise<void> {
+  await getDB().mealPreps.where("id").equals(id).modify((m) => {
+    m.conversations.push(message)
+    m.updatedAt = Date.now()
+  })
+}
+
+export async function setMealPrepConversations(id: string, conversations: Message[]): Promise<void> {
+  await getDB().mealPreps.update(id, { conversations, updatedAt: Date.now() })
+}

--- a/recipe-app/lib/db/schema.ts
+++ b/recipe-app/lib/db/schema.ts
@@ -1,16 +1,23 @@
 import Dexie, { type EntityTable } from "dexie"
 import type { Recipe } from "@/types/recipe"
 import type { Meal } from "@/types/meal"
+import type { MealPrep } from "@/types/meal-prep"
 
 class RecipeAppDB extends Dexie {
   recipes!: EntityTable<Recipe, "id">
   meals!: EntityTable<Meal, "id">
+  mealPreps!: EntityTable<MealPrep, "id">
 
   constructor() {
     super("recipe-app-db")
     this.version(1).stores({
       recipes: "id, title, createdAt, updatedAt, *tags",
       meals: "id, title, createdAt, updatedAt",
+    })
+    this.version(2).stores({
+      recipes: "id, title, createdAt, updatedAt, *tags",
+      meals: "id, title, createdAt, updatedAt",
+      mealPreps: "id, title, createdAt, updatedAt",
     })
   }
 }

--- a/recipe-app/lib/hooks/useMealPrepChat.ts
+++ b/recipe-app/lib/hooks/useMealPrepChat.ts
@@ -1,0 +1,73 @@
+"use client"
+
+import { useState, useCallback } from "react"
+import { useChat } from "./useChat"
+import type { ProviderConfig } from "@/types/ai"
+import type { Message } from "@/types/message"
+import { DEFAULT_PROVIDER_CONFIG } from "@/types/ai"
+import type { ExistingRecipeSummaryForPrep } from "@/lib/ai/prompts/meal-prep-planning"
+
+export interface ParsedMealPrepPlan {
+  title: string
+  description: string
+  suggestions: Array<{
+    title: string
+    servingsPerWeek: number
+    recipeId: string | null
+    isNew: boolean
+    estimatedMacros: {
+      calories: number
+      protein: number
+      carbs: number
+      fat: number
+    }
+  }>
+}
+
+function extractMealPrepPlan(text: string): ParsedMealPrepPlan | null {
+  const fenceRegex = /```json\s*([\s\S]*?)```/g
+  let match
+  while ((match = fenceRegex.exec(text)) !== null) {
+    try {
+      const parsed = JSON.parse(match[1])
+      if (parsed.__type === "meal_prep_plan") {
+        const { __type, ...data } = parsed
+        return data as ParsedMealPrepPlan
+      }
+    } catch {
+      // continue
+    }
+  }
+  return null
+}
+
+interface UseMealPrepChatOptions {
+  existingRecipes?: ExistingRecipeSummaryForPrep[]
+  config?: ProviderConfig
+  onMessagesChange?: (messages: Message[]) => void
+}
+
+export function useMealPrepChat({ existingRecipes = [], config, onMessagesChange }: UseMealPrepChatOptions = {}) {
+  const [pendingMealPrepPlan, setPendingMealPrepPlan] = useState<ParsedMealPrepPlan | null>(null)
+  const [providerConfig, setProviderConfig] = useState<ProviderConfig>(
+    config ?? DEFAULT_PROVIDER_CONFIG
+  )
+
+  const chat = useChat({
+    endpoint: "/api/chat/meal-prep",
+    buildExtraBody: () => ({
+      providerId: providerConfig.providerId,
+      modelId: providerConfig.modelId,
+      existingRecipes,
+    }),
+    onComplete: (fullText, finalMessages) => {
+      const parsed = extractMealPrepPlan(fullText)
+      if (parsed) setPendingMealPrepPlan(parsed)
+      onMessagesChange?.(finalMessages)
+    },
+  })
+
+  const clearPendingMealPrepPlan = useCallback(() => setPendingMealPrepPlan(null), [])
+
+  return { ...chat, pendingMealPrepPlan, clearPendingMealPrepPlan, providerConfig, setProviderConfig }
+}

--- a/recipe-app/lib/hooks/useMealPreps.ts
+++ b/recipe-app/lib/hooks/useMealPreps.ts
@@ -1,0 +1,13 @@
+"use client"
+
+import { useLiveQuery } from "dexie-react-hooks"
+import { getDB } from "@/lib/db/schema"
+import type { MealPrep } from "@/types/meal-prep"
+
+export function useMealPreps(): MealPrep[] | undefined {
+  return useLiveQuery(() => getDB().mealPreps.orderBy("updatedAt").reverse().toArray())
+}
+
+export function useMealPrep(id: string): MealPrep | undefined {
+  return useLiveQuery(() => getDB().mealPreps.get(id), [id])
+}

--- a/recipe-app/types/meal-prep.ts
+++ b/recipe-app/types/meal-prep.ts
@@ -1,0 +1,21 @@
+import type { Message } from "./message"
+
+export interface MealPrepRecipeRef {
+  recipeId: string
+  servingsPerWeek: number
+}
+
+export interface MealPrep {
+  id: string
+  title: string
+  description: string
+  recipeRefs: MealPrepRecipeRef[]
+  conversations: Message[]
+  modelId: string
+  providerId: string
+  createdAt: number
+  updatedAt: number
+}
+
+export type MealPrepCreate = Omit<MealPrep, "id" | "createdAt" | "updatedAt">
+export type MealPrepUpdate = Partial<MealPrepCreate>

--- a/recipe-app/types/meal-prep.ts
+++ b/recipe-app/types/meal-prep.ts
@@ -3,6 +3,12 @@ import type { Message } from "./message"
 export interface MealPrepRecipeRef {
   recipeId: string
   servingsPerWeek: number
+  estimatedMacros?: {
+    calories: number
+    protein: number
+    carbs: number
+    fat: number
+  }
 }
 
 export interface MealPrep {

--- a/recipe-app/types/recipe.ts
+++ b/recipe-app/types/recipe.ts
@@ -1,5 +1,13 @@
 import type { Message } from "./message"
 
+export interface Macros {
+  calories: number
+  protein: number
+  carbs: number
+  fat: number
+  fiber?: number
+}
+
 export interface Ingredient {
   name: string
   amount: number
@@ -26,6 +34,7 @@ export interface Recipe {
   conversations: Message[]
   modelId: string
   providerId: string
+  macros?: Macros
   createdAt: number
   updatedAt: number
 }


### PR DESCRIPTION
Tightens the meal planning system prompt so the AI only outputs dish names + roles in the structured JSON block, instead of writing full recipe instructions into the chat.\n\nThe root cause was the prompt didn't explicitly prohibit writing recipes — only told the AI to output a JSON block at the end, which it ignored in favor of being \"helpful\".

---
_Generated by [Claude Code](https://claude.ai/code/session_012BY9VPHoVJstziT1GHcaZH)_