### PR TITLE
Fix: meal plan save creates stub recipes and auto-generates them

### DIFF
--- a/recipe-app/app/meals/new/NewMealClient.tsx
+++ b/recipe-app/app/meals/new/NewMealClient.tsx
@@ -8,6 +8,7 @@ import { ChatPanel } from "@/components/chat/ChatPanel"
 import { useMealChat, type ParsedMealPlan } from "@/lib/hooks/useMealChat"
 import { useRecipes } from "@/lib/hooks/useRecipes"
 import { createMeal } from "@/lib/db/meals"
+import { createRecipe } from "@/lib/db/recipes"
 import { toast } from "sonner"
 import type { RecipeRole } from "@/types/meal"
 
@@ -51,19 +52,39 @@ export function NewMealClient() {
     if (!activePlan) return
     setSaving(true)
     try {
-      const recipeRefs = activePlan.suggestions
-        .filter((s) => s.recipeId !== null)
-        .map((s) => ({ recipeId: s.recipeId!, role: s.role as RecipeRole }))
+      // Create stub recipes for any new suggestions so the meal isn't empty.
+      // Stubs have no ingredients/steps; navigating to them auto-triggers AI generation.
+      const resolvedRefs = await Promise.all(
+        activePlan.suggestions.map(async (s) => {
+          if (s.recipeId) {
+            return { recipeId: s.recipeId, role: s.role as RecipeRole }
+          }
+          const stub = await createRecipe({
+            title: s.title,
+            description: "",
+            servings: 0,
+            prepTime: 0,
+            cookTime: 0,
+            tags: [],
+            ingredients: [],
+            steps: [],
+            conversations: [],
+            modelId: providerConfig.modelId,
+            providerId: providerConfig.providerId,
+          })
+          return { recipeId: stub.id, role: s.role as RecipeRole }
+        })
+      )
 
       const meal = await createMeal({
         title: activePlan.title,
         description: activePlan.description,
-        recipeRefs,
+        recipeRefs: resolvedRefs,
         conversations: messages,
         modelId: providerConfig.modelId,
         providerId: providerConfig.providerId,
       })
-      toast.success("Meal saved!")
+      toast.success("Meal saved! Open each recipe to generate it.")
       router.push(`/meals/${meal.id}`)
     } catch (err) {
       toast.error(err instanceof Error ? err.message : "Save failed")
@@ -150,7 +171,7 @@ export function NewMealClient() {
                     )}
                     {s.isNew && (
                       <p className="text-xs mt-0.5" style={{ color: "var(--color-muted-foreground)" }}>
-                        New recipe needed
+                        Will be generated when you open it
                       </p>
                     )}
                   </div>

--- a/recipe-app/app/recipes/[id]/RecipeDetailClient.tsx
+++ b/recipe-app/app/recipes/[id]/RecipeDetailClient.tsx
@@ -43,7 +43,19 @@ export function RecipeDetailClient({ id }: RecipeDetailClientProps) {
     if (recipe && recipe.conversations.length > 0 && messages.length === 0) {
       setMessages(recipe.conversations)
     }
-  // Only run when recipe first loads
+  // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [recipe?.id])
+
+  // Auto-generate if this is a stub recipe (created from meal planning but not yet built)
+  useEffect(() => {
+    if (
+      recipe &&
+      recipe.ingredients.length === 0 &&
+      recipe.steps.length === 0 &&
+      recipe.conversations.length === 0
+    ) {
+      send(`Please create a complete recipe for: ${recipe.title}`)
+    }
   // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [recipe?.id])
 

--- a/recipe-app/components/meal/MealRecipeList.tsx
+++ b/recipe-app/components/meal/MealRecipeList.tsx
@@ -1,7 +1,7 @@
 "use client"
 
 import Link from "next/link"
-import { ChefHat, ExternalLink } from "lucide-react"
+import { ChefHat, ExternalLink, Sparkles } from "lucide-react"
 import type { RecipeRef } from "@/types/meal"
 import type { Recipe } from "@/types/recipe"
 
@@ -43,9 +43,13 @@ export function MealRecipeList({ recipeRefs, recipes }: MealRecipeListProps) {
       {sorted.map((ref, i) => {
         const recipe = recipes[ref.recipeId]
         const colors = roleColor[ref.role] ?? roleColor.main
+        const isStub = recipe && recipe.ingredients.length === 0 && recipe.steps.length === 0
         return (
           <div key={i} className="flex items-center gap-3 p-3 rounded-xl border"
-            style={{ borderColor: "var(--color-border)", backgroundColor: "var(--color-card)" }}>
+            style={{
+              borderColor: isStub ? "#FED7AA" : "var(--color-border)",
+              backgroundColor: isStub ? "#FFF7ED" : "var(--color-card)",
+            }}>
             <div className="w-8 h-8 rounded-lg flex items-center justify-center shrink-0"
               style={{ backgroundColor: colors.bg, color: colors.text }}>
               <ChefHat size={15} />
@@ -56,6 +60,11 @@ export function MealRecipeList({ recipeRefs, recipes }: MealRecipeListProps) {
                   style={{ backgroundColor: colors.bg, color: colors.text }}>
                   {roleLabel[ref.role]}
                 </span>
+                {isStub && (
+                  <span className="text-xs font-medium" style={{ color: "#C2410C" }}>
+                    Not generated yet
+                  </span>
+                )}
               </div>
               {recipe ? (
                 <p className="text-sm font-medium mt-0.5 truncate"
@@ -71,12 +80,21 @@ export function MealRecipeList({ recipeRefs, recipes }: MealRecipeListProps) {
             {recipe && (
               <Link
                 href={`/recipes/${ref.recipeId}`}
-                className="shrink-0 p-1.5 rounded-lg transition-colors hover:bg-muted"
-                style={{ color: "var(--color-muted-foreground)" }}
-                title="View recipe"
+                className="shrink-0 flex items-center gap-1 px-2.5 py-1.5 rounded-lg text-xs font-medium transition-colors"
+                style={isStub ? {
+                  backgroundColor: "#EA580C",
+                  color: "white",
+                } : {
+                  color: "var(--color-muted-foreground)",
+                }}
+                title={isStub ? "Generate recipe" : "View recipe"}
                 onClick={(e) => e.stopPropagation()}
               >
-                <ExternalLink size={14} />
+                {isStub ? (
+                  <><Sparkles size={12} /> Generate</>
+                ) : (
+                  <ExternalLink size={14} />
+                )}
               </Link>
             )}
           </div>


### PR DESCRIPTION
Fixes two bugs in the meal planning flow:\n\n**Bug 1 — Meal saves empty:** `handleSaveMeal` was filtering out `isNew: true` suggestions (recipeId === null), so new dishes were discarded. Now it creates a stub Recipe for each new dish first, then links all refs to the meal.\n\n**Bug 2 — No generation flow:** Opening a stub recipe (no ingredients, no steps, no prior conversation) now auto-sends \"Please create a complete recipe for: [title]\" so generation starts immediately.\n\n**UX:** Stub recipes in the meal detail list are highlighted orange with a \"Generate\" button so it's obvious which ones still need to be built."

---
_Generated by [Claude Code](https://claude.ai/code/session_012BY9VPHoVJstziT1GHcaZH)_