### PR TITLE
Fix: recipe modification no longer re-asks creation questions

### DIFF
--- a/recipe-app/lib/hooks/useChat.ts
+++ b/recipe-app/lib/hooks/useChat.ts
@@ -26,6 +26,12 @@ export function useChat({ endpoint, onComplete, buildExtraBody }: UseChatOptions
   const [error, setError] = useState<string | null>(null)
   const abortRef = useRef<AbortController | null>(null)
 
+  // Refs so send() always calls the latest versions without being recreated on every render
+  const buildExtraBodyRef = useRef(buildExtraBody)
+  buildExtraBodyRef.current = buildExtraBody
+  const onCompleteRef = useRef(onComplete)
+  onCompleteRef.current = onComplete
+
   const send = useCallback(
     async (content: string) => {
       if (isStreaming) return
@@ -47,7 +53,7 @@ export function useChat({ endpoint, onComplete, buildExtraBody }: UseChatOptions
       abortRef.current = controller
 
       try {
-        const extraBody = buildExtraBody ? buildExtraBody() : {}
+        const extraBody = buildExtraBodyRef.current ? buildExtraBodyRef.current() : {}
         const res = await fetch(endpoint, {
           method: "POST",
           headers: { "Content-Type": "application/json" },
@@ -81,7 +87,7 @@ export function useChat({ endpoint, onComplete, buildExtraBody }: UseChatOptions
         const finalMessages = [...updatedMessages, assistantMessage]
         setMessages(finalMessages)
         setStreamingContent("")
-        onComplete?.(fullText, finalMessages)
+        onCompleteRef.current?.(fullText, finalMessages)
       } catch (err) {
         if ((err as Error).name === "AbortError") return
         const msg = err instanceof Error ? err.message : "Unknown error"


### PR DESCRIPTION
**Root cause:** `send()` was memoized with `useCallback` but `buildExtraBody` wasn't in its dependency array. On first render, `recipe` is `undefined` (Dexie hasn't resolved yet), so `buildExtraBody` closes over `recipe: null`. By the time the recipe loads and the user sends a message, `send()` is still calling the stale closure — passing `recipe: null` to the API, which then uses the creation prompt and asks setup questions all over again.\n\n**Fix:** Store `buildExtraBody` and `onComplete` in refs that are updated on every render. `send()` reads from the ref at call time, always getting the current values without needing to be recreated."

---
_Generated by [Claude Code](https://claude.ai/code/session_012BY9VPHoVJstziT1GHcaZH)_