### PR TITLE
Hide raw JSON during streaming; show animated GeneratingCard

### DIFF
--- a/recipe-app/components/chat/ChatMessage.tsx
+++ b/recipe-app/components/chat/ChatMessage.tsx
@@ -8,7 +8,7 @@ interface ChatMessageProps {
 }
 
 function renderContent(content: string) {
-  // Strip JSON code blocks from display — they get shown via SaveRecipeButton instead
+  // Strip complete JSON blocks — they're shown as UI (SaveRecipeButton, meal plan card)
   const stripped = content.replace(/```json[\s\S]*?```/g, "").trim()
   if (!stripped) return null
 
@@ -38,6 +38,37 @@ function renderContent(content: string) {
   })
 }
 
+// Detect whether content has an open (not-yet-closed) JSON block mid-stream.
+// Returns the text before the block and a label for what's being generated.
+function splitStreamingContent(content: string): {
+  text: string
+  isGenerating: boolean
+  generatingLabel: string
+} {
+  // Remove any complete JSON blocks first
+  const withoutComplete = content.replace(/```json[\s\S]*?```/g, "")
+
+  // Check for an open block (```json without a matching closing ```)
+  const openIdx = withoutComplete.lastIndexOf("```json")
+  if (openIdx === -1) {
+    return { text: withoutComplete.trim(), isGenerating: false, generatingLabel: "" }
+  }
+
+  const before = withoutComplete.slice(0, openIdx).trim()
+  const partialJson = withoutComplete.slice(openIdx)
+
+  // Peek at __type to pick a friendly label
+  const typeMatch = partialJson.match(/"__type"\s*:\s*"([^"]+)"/)
+  const type = typeMatch?.[1] ?? ""
+  const label =
+    type === "recipe" ? "Building recipe…"
+    : type === "recipe_update" ? "Updating recipe…"
+    : type === "meal_plan" ? "Building meal plan…"
+    : "Generating…"
+
+  return { text: before, isGenerating: true, generatingLabel: label }
+}
+
 export function ChatMessage({ message }: ChatMessageProps) {
   const isUser = message.role === "user"
 
@@ -62,30 +93,60 @@ export function ChatMessage({ message }: ChatMessageProps) {
   )
 }
 
+function GeneratingCard({ label }: { label: string }) {
+  return (
+    <div className="flex items-center gap-2.5 px-3 py-2.5 rounded-xl mt-1.5"
+      style={{ backgroundColor: "var(--color-accent)", border: "1px solid var(--color-border)" }}>
+      <span className="inline-flex gap-1 items-center shrink-0">
+        <span className="w-1.5 h-1.5 rounded-full animate-bounce"
+          style={{ backgroundColor: "var(--color-primary)", animationDelay: "0ms" }} />
+        <span className="w-1.5 h-1.5 rounded-full animate-bounce"
+          style={{ backgroundColor: "var(--color-primary)", animationDelay: "150ms" }} />
+        <span className="w-1.5 h-1.5 rounded-full animate-bounce"
+          style={{ backgroundColor: "var(--color-primary)", animationDelay: "300ms" }} />
+      </span>
+      <span className="text-xs font-medium" style={{ color: "var(--color-primary)" }}>
+        {label}
+      </span>
+    </div>
+  )
+}
+
 interface StreamingMessageProps {
   content: string
 }
 
 export function StreamingMessage({ content }: StreamingMessageProps) {
-  const stripped = content.replace(/```json[\s\S]*?```/g, "").trim()
+  const { text, isGenerating, generatingLabel } = splitStreamingContent(content)
+
+  const hasText = text.length > 0
+
   return (
     <div className="flex justify-start">
-      <div
-        className="max-w-[85%] rounded-2xl rounded-tl-sm px-4 py-2.5 text-sm"
-        style={{ backgroundColor: "var(--color-muted)", color: "var(--color-foreground)" }}
-      >
-        {stripped ? (
-          <span className="streaming-cursor">{stripped}</span>
-        ) : (
-          <span className="inline-flex gap-1 items-center py-1">
-            <span className="w-1.5 h-1.5 rounded-full animate-bounce"
-              style={{ backgroundColor: "var(--color-muted-foreground)", animationDelay: "0ms" }} />
-            <span className="w-1.5 h-1.5 rounded-full animate-bounce"
-              style={{ backgroundColor: "var(--color-muted-foreground)", animationDelay: "150ms" }} />
-            <span className="w-1.5 h-1.5 rounded-full animate-bounce"
-              style={{ backgroundColor: "var(--color-muted-foreground)", animationDelay: "300ms" }} />
-          </span>
+      <div className="max-w-[85%] space-y-1">
+        {/* Conversational text */}
+        {(hasText || !isGenerating) && (
+          <div
+            className="rounded-2xl rounded-tl-sm px-4 py-2.5 text-sm"
+            style={{ backgroundColor: "var(--color-muted)", color: "var(--color-foreground)" }}
+          >
+            {hasText ? (
+              <span className={cn(!isGenerating && "streaming-cursor")}>{text}</span>
+            ) : (
+              <span className="inline-flex gap-1 items-center py-1">
+                <span className="w-1.5 h-1.5 rounded-full animate-bounce"
+                  style={{ backgroundColor: "var(--color-muted-foreground)", animationDelay: "0ms" }} />
+                <span className="w-1.5 h-1.5 rounded-full animate-bounce"
+                  style={{ backgroundColor: "var(--color-muted-foreground)", animationDelay: "150ms" }} />
+                <span className="w-1.5 h-1.5 rounded-full animate-bounce"
+                  style={{ backgroundColor: "var(--color-muted-foreground)", animationDelay: "300ms" }} />
+              </span>
+            )}
+          </div>
         )}
+
+        {/* Generating card — replaces raw JSON during streaming */}
+        {isGenerating && <GeneratingCard label={generatingLabel} />}
       </div>
     </div>
   )


### PR DESCRIPTION
Fixes the chaotic streaming chat experience where raw JSON blocks were visible while the AI was generating structured data.

## Changes

- `splitStreamingContent()` — detects an open (not-yet-closed) ` ```json ` block mid-stream and peeks at `__type` to pick a friendly label ("Building recipe…", "Updating recipe…", "Building meal plan…")
- `GeneratingCard` — animated pulsing dots + label shown in place of raw JSON while streaming
- `StreamingMessage` — now shows the conversational text bubble separately from the GeneratingCard; if no text yet, shows a neutral thinking animation in the text bubble

## Behavior

- User sends a message → neutral bouncing dots appear immediately
- AI starts talking → conversational text appears with streaming cursor
- AI emits ` ```json ` → raw JSON is hidden; GeneratingCard appears below with label e.g. "Building recipe…"
- Stream ends → GeneratingCard disappears; SaveRecipeButton / meal plan card UI renders as before

---
_Generated by [Claude Code](https://claude.ai/code/session_012BY9VPHoVJstziT1GHcaZH)_