### PR TITLE
Make UI mobile-friendly across all pages

### DIFF
--- a/recipe-app/app/meals/[id]/MealDetailClient.tsx
+++ b/recipe-app/app/meals/[id]/MealDetailClient.tsx
@@ -1,6 +1,6 @@
 "use client"
 
-import { useEffect, useMemo } from "react"
+import { useEffect, useMemo, useState } from "react"
 import { ArrowLeft, ChefHat } from "lucide-react"
 import Link from "next/link"
 import { useMeal } from "@/lib/hooks/useMeals"
@@ -18,6 +18,7 @@ interface MealDetailClientProps {
 export function MealDetailClient({ id }: MealDetailClientProps) {
   const meal = useMeal(id)
   const allRecipes = useRecipes()
+  const [mobileTab, setMobileTab] = useState<"recipes" | "chat">("recipes")
 
   const recipesMap = useMemo<Record<string, Recipe>>(() => {
     const map: Record<string, Recipe> = {}
@@ -108,10 +109,27 @@ export function MealDetailClient({ id }: MealDetailClientProps) {
         </Link>
       </div>
 
+      {/* Mobile tab switcher */}
+      <div className="flex border-b shrink-0 md:hidden" style={{ borderColor: "var(--color-border)" }}>
+        {(["recipes", "chat"] as const).map((tab) => (
+          <button
+            key={tab}
+            onClick={() => setMobileTab(tab)}
+            className="flex-1 py-2.5 text-sm font-medium capitalize transition-colors"
+            style={mobileTab === tab ? {
+              color: "var(--color-primary)",
+              borderBottom: "2px solid var(--color-primary)",
+            } : { color: "var(--color-muted-foreground)" }}
+          >
+            {tab === "recipes" ? "Recipes" : "Chat"}
+          </button>
+        ))}
+      </div>
+
       {/* Split: recipe list + chat */}
       <div className="flex-1 flex overflow-hidden">
         {/* Recipe list */}
-        <div className="flex-1 overflow-y-auto p-6">
+        <div className={mobileTab === "recipes" ? "flex flex-col flex-1 overflow-y-auto p-6" : "hidden md:flex md:flex-col md:flex-1 md:overflow-y-auto md:p-6"}>
           <h2 className="text-sm font-semibold uppercase tracking-wide mb-4"
             style={{ color: "var(--color-muted-foreground)" }}>
             Recipes in this meal
@@ -120,8 +138,10 @@ export function MealDetailClient({ id }: MealDetailClientProps) {
         </div>
 
         {/* Chat */}
-        <div className="w-96 shrink-0 border-l flex flex-col overflow-hidden"
-          style={{ borderColor: "var(--color-border)" }}>
+        <div
+          className={mobileTab === "chat" ? "flex flex-col flex-1 overflow-hidden md:w-96 md:flex-none md:border-l" : "hidden md:flex md:flex-col md:w-96 md:shrink-0 md:border-l md:overflow-hidden"}
+          style={{ borderColor: "var(--color-border)" }}
+        >
           <ChatPanel
             messages={messages}
             isStreaming={isStreaming}

--- a/recipe-app/app/meals/[id]/cook/MealCookClient.tsx
+++ b/recipe-app/app/meals/[id]/cook/MealCookClient.tsx
@@ -52,26 +52,20 @@ export function MealCookClient({ id }: MealCookClientProps) {
 
   return (
     <CookingLayout title={meal.title}>
-      <div className="flex h-full">
-        {/* Recipe tab list */}
+      <div className="flex flex-col h-full">
+        {/* Mobile: horizontal scrolling dish tabs */}
         {mealRecipes.length > 1 && (
-          <div className="w-48 shrink-0 border-r overflow-y-auto p-3"
+          <div className="flex overflow-x-auto border-b shrink-0 lg:hidden px-2 py-1.5 gap-1"
             style={{ borderColor: "var(--color-border)" }}>
-            <p className="text-xs font-semibold uppercase tracking-wide mb-2 px-2"
-              style={{ color: "var(--color-muted-foreground)" }}>
-              Dishes
-            </p>
             {mealRecipes.map((recipe, i) => (
               <button
                 key={recipe.id}
                 onClick={() => setActiveRecipeIndex(i)}
-                className="w-full text-left px-3 py-2 rounded-xl text-sm font-medium mb-1 transition-colors"
+                className="shrink-0 px-3 py-1.5 rounded-lg text-sm font-medium whitespace-nowrap transition-colors"
                 style={i === activeRecipeIndex ? {
                   backgroundColor: "var(--color-accent)",
                   color: "var(--color-primary)",
-                } : {
-                  color: "var(--color-muted-foreground)",
-                }}
+                } : { color: "var(--color-muted-foreground)" }}
               >
                 {recipe.title}
               </button>
@@ -79,17 +73,45 @@ export function MealCookClient({ id }: MealCookClientProps) {
           </div>
         )}
 
-        {/* Recipe view */}
-        <div className="flex-1 overflow-hidden">
-          {activeRecipe ? (
-            <CookingRecipeView recipe={activeRecipe} />
-          ) : (
-            <div className="flex items-center justify-center h-full">
-              <p style={{ color: "var(--color-muted-foreground)" }}>
-                No recipes found in this meal.
+        <div className="flex flex-1 overflow-hidden">
+          {/* Desktop: vertical sidebar */}
+          {mealRecipes.length > 1 && (
+            <div className="hidden lg:block w-48 shrink-0 border-r overflow-y-auto p-3"
+              style={{ borderColor: "var(--color-border)" }}>
+              <p className="text-xs font-semibold uppercase tracking-wide mb-2 px-2"
+                style={{ color: "var(--color-muted-foreground)" }}>
+                Dishes
               </p>
+              {mealRecipes.map((recipe, i) => (
+                <button
+                  key={recipe.id}
+                  onClick={() => setActiveRecipeIndex(i)}
+                  className="w-full text-left px-3 py-2 rounded-xl text-sm font-medium mb-1 transition-colors"
+                  style={i === activeRecipeIndex ? {
+                    backgroundColor: "var(--color-accent)",
+                    color: "var(--color-primary)",
+                  } : {
+                    color: "var(--color-muted-foreground)",
+                  }}
+                >
+                  {recipe.title}
+                </button>
+              ))}
             </div>
           )}
+
+          {/* Recipe view */}
+          <div className="flex-1 overflow-hidden">
+            {activeRecipe ? (
+              <CookingRecipeView recipe={activeRecipe} />
+            ) : (
+              <div className="flex items-center justify-center h-full">
+                <p style={{ color: "var(--color-muted-foreground)" }}>
+                  No recipes found in this meal.
+                </p>
+              </div>
+            )}
+          </div>
         </div>
       </div>
     </CookingLayout>

--- a/recipe-app/app/meals/new/NewMealClient.tsx
+++ b/recipe-app/app/meals/new/NewMealClient.tsx
@@ -1,7 +1,7 @@
 "use client"
 
 import { useEffect, useState } from "react"
-import { ArrowLeft, Plus, Check } from "lucide-react"
+import { ArrowLeft, Plus, Check, Utensils, X } from "lucide-react"
 import Link from "next/link"
 import { useRouter } from "next/navigation"
 import { ChatPanel } from "@/components/chat/ChatPanel"
@@ -17,6 +17,7 @@ export function NewMealClient() {
   const recipes = useRecipes()
   const [saving, setSaving] = useState(false)
   const [savedMealPlan, setSavedMealPlan] = useState<ParsedMealPlan | null>(null)
+  const [showPlanSheet, setShowPlanSheet] = useState(false)
 
   const existingRecipes = (recipes ?? []).map((r) => ({
     id: r.id,
@@ -129,71 +130,137 @@ export function NewMealClient() {
           />
         </div>
 
-        {/* Meal plan preview */}
+        {/* Meal plan preview — desktop sidebar */}
         {activePlan && (
-          <div className="w-80 shrink-0 border-l overflow-y-auto p-4"
+          <div className="hidden md:flex md:flex-col w-80 shrink-0 border-l overflow-y-auto p-4"
             style={{ borderColor: "var(--color-border)", backgroundColor: "var(--color-card)" }}>
-            <div className="flex items-start justify-between gap-2 mb-4">
-              <div>
-                <h2 className="text-sm font-semibold" style={{ color: "var(--color-foreground)" }}>
-                  {activePlan.title}
-                </h2>
-                <p className="text-xs mt-0.5" style={{ color: "var(--color-muted-foreground)" }}>
-                  {activePlan.description}
-                </p>
-              </div>
-              <button
-                onClick={clearPendingMealPlan}
-                className="text-xs px-2 py-1 rounded-md transition-colors hover:bg-muted"
-                style={{ color: "var(--color-muted-foreground)" }}
-              >
-                Clear
-              </button>
-            </div>
-
-            <div className="space-y-2 mb-4">
-              {activePlan.suggestions.map((s, i) => (
-                <div key={i} className="flex items-center gap-3 p-3 rounded-xl border"
-                  style={{ borderColor: "var(--color-border)", backgroundColor: "var(--color-background)" }}>
-                  <div className="flex-1 min-w-0">
-                    <span className="text-xs font-medium capitalize"
-                      style={{ color: "var(--color-muted-foreground)" }}>
-                      {s.role}
-                    </span>
-                    <p className="text-sm font-medium mt-0.5 truncate"
-                      style={{ color: "var(--color-foreground)" }}>
-                      {s.title}
-                    </p>
-                    {s.recipeId && (
-                      <p className="text-xs mt-0.5" style={{ color: "var(--color-primary)" }}>
-                        Using saved recipe
-                      </p>
-                    )}
-                    {s.isNew && (
-                      <p className="text-xs mt-0.5" style={{ color: "var(--color-muted-foreground)" }}>
-                        Will be generated when you open it
-                      </p>
-                    )}
-                  </div>
-                  {s.recipeId && (
-                    <Check size={14} className="shrink-0" style={{ color: "var(--color-primary)" }} />
-                  )}
-                </div>
-              ))}
-            </div>
-
-            <button
-              onClick={handleSaveMeal}
-              disabled={saving}
-              className="w-full flex items-center justify-center gap-2 py-2.5 rounded-xl text-sm font-semibold text-white transition-opacity disabled:opacity-60 hover:opacity-90"
-              style={{ backgroundColor: "#EA580C" }}
-            >
-              <Plus size={15} />
-              {saving ? "Saving…" : "Save Meal"}
-            </button>
+            <PlanContent
+              plan={activePlan}
+              saving={saving}
+              onClear={clearPendingMealPlan}
+              onSave={handleSaveMeal}
+            />
           </div>
         )}
       </div>
+
+      {/* Mobile: floating "View Plan" button */}
+      {activePlan && (
+        <button
+          onClick={() => setShowPlanSheet(true)}
+          className="md:hidden fixed bottom-20 right-4 flex items-center gap-2 px-4 py-2.5 rounded-full text-sm font-semibold text-white shadow-lg z-30 transition-opacity hover:opacity-90"
+          style={{ backgroundColor: "#EA580C" }}
+        >
+          <Utensils size={15} />
+          View Plan ({activePlan.suggestions.length})
+        </button>
+      )}
+
+      {/* Mobile: plan bottom sheet */}
+      {showPlanSheet && activePlan && (
+        <div
+          className="md:hidden fixed inset-0 z-50 flex flex-col justify-end"
+          style={{ backgroundColor: "rgba(0,0,0,0.4)" }}
+          onClick={() => setShowPlanSheet(false)}
+        >
+          <div
+            className="rounded-t-2xl max-h-[80vh] overflow-y-auto p-4"
+            style={{ backgroundColor: "var(--color-card)" }}
+            onClick={(e) => e.stopPropagation()}
+          >
+            <div className="flex items-center justify-between mb-4">
+              <span className="text-sm font-semibold" style={{ color: "var(--color-foreground)" }}>
+                Meal Plan
+              </span>
+              <button
+                onClick={() => setShowPlanSheet(false)}
+                className="p-1.5 rounded-lg"
+                style={{ color: "var(--color-muted-foreground)" }}
+              >
+                <X size={16} />
+              </button>
+            </div>
+            <PlanContent
+              plan={activePlan}
+              saving={saving}
+              onClear={() => { clearPendingMealPlan(); setShowPlanSheet(false) }}
+              onSave={handleSaveMeal}
+            />
+          </div>
+        </div>
+      )}
     </div>
+  )
+}
+
+interface PlanContentProps {
+  plan: ParsedMealPlan
+  saving: boolean
+  onClear: () => void
+  onSave: () => void
+}
+
+function PlanContent({ plan, saving, onClear, onSave }: PlanContentProps) {
+  return (
+    <>
+      <div className="flex items-start justify-between gap-2 mb-4">
+        <div>
+          <h2 className="text-sm font-semibold" style={{ color: "var(--color-foreground)" }}>
+            {plan.title}
+          </h2>
+          <p className="text-xs mt-0.5" style={{ color: "var(--color-muted-foreground)" }}>
+            {plan.description}
+          </p>
+        </div>
+        <button
+          onClick={onClear}
+          className="text-xs px-2 py-1 rounded-md transition-colors hover:bg-muted"
+          style={{ color: "var(--color-muted-foreground)" }}
+        >
+          Clear
+        </button>
+      </div>
+
+      <div className="space-y-2 mb-4">
+        {plan.suggestions.map((s, i) => (
+          <div key={i} className="flex items-center gap-3 p-3 rounded-xl border"
+            style={{ borderColor: "var(--color-border)", backgroundColor: "var(--color-background)" }}>
+            <div className="flex-1 min-w-0">
+              <span className="text-xs font-medium capitalize"
+                style={{ color: "var(--color-muted-foreground)" }}>
+                {s.role}
+              </span>
+              <p className="text-sm font-medium mt-0.5 truncate"
+                style={{ color: "var(--color-foreground)" }}>
+                {s.title}
+              </p>
+              {s.recipeId && (
+                <p className="text-xs mt-0.5" style={{ color: "var(--color-primary)" }}>
+                  Using saved recipe
+                </p>
+              )}
+              {s.isNew && (
+                <p className="text-xs mt-0.5" style={{ color: "var(--color-muted-foreground)" }}>
+                  Will be generated when you open it
+                </p>
+              )}
+            </div>
+            {s.recipeId && (
+              <Check size={14} className="shrink-0" style={{ color: "var(--color-primary)" }} />
+            )}
+          </div>
+        ))}
+      </div>
+
+      <button
+        onClick={onSave}
+        disabled={saving}
+        className="w-full flex items-center justify-center gap-2 py-2.5 rounded-xl text-sm font-semibold text-white transition-opacity disabled:opacity-60 hover:opacity-90"
+        style={{ backgroundColor: "#EA580C" }}
+      >
+        <Plus size={15} />
+        {saving ? "Saving…" : "Save Meal"}
+      </button>
+    </>
   )
 }

--- a/recipe-app/app/recipes/[id]/RecipeDetailClient.tsx
+++ b/recipe-app/app/recipes/[id]/RecipeDetailClient.tsx
@@ -1,6 +1,6 @@
 "use client"
 
-import { useEffect } from "react"
+import { useEffect, useState } from "react"
 import { ArrowLeft } from "lucide-react"
 import Link from "next/link"
 import { useRecipe } from "@/lib/hooks/useRecipes"
@@ -16,6 +16,7 @@ interface RecipeDetailClientProps {
 
 export function RecipeDetailClient({ id }: RecipeDetailClientProps) {
   const recipe = useRecipe(id)
+  const [mobileTab, setMobileTab] = useState<"recipe" | "chat">("recipe")
 
   const {
     messages,
@@ -45,6 +46,11 @@ export function RecipeDetailClient({ id }: RecipeDetailClientProps) {
     }
   // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [recipe?.id])
+
+  // Switch to chat tab on mobile when a pending recipe appears
+  useEffect(() => {
+    if (pendingRecipe) setMobileTab("chat")
+  }, [pendingRecipe])
 
   // Auto-generate if this is a stub recipe (created from meal planning but not yet built)
   useEffect(() => {
@@ -93,16 +99,39 @@ export function RecipeDetailClient({ id }: RecipeDetailClientProps) {
         </h1>
       </div>
 
+      {/* Mobile tab switcher */}
+      <div className="flex border-b shrink-0 md:hidden" style={{ borderColor: "var(--color-border)" }}>
+        {(["recipe", "chat"] as const).map((tab) => (
+          <button
+            key={tab}
+            onClick={() => setMobileTab(tab)}
+            className="flex-1 py-2.5 text-sm font-medium capitalize transition-colors relative"
+            style={mobileTab === tab ? {
+              color: "var(--color-primary)",
+              borderBottom: "2px solid var(--color-primary)",
+            } : { color: "var(--color-muted-foreground)" }}
+          >
+            {tab}
+            {tab === "chat" && pendingRecipe && mobileTab !== "chat" && (
+              <span className="absolute top-2.5 right-[calc(50%-2rem)] w-1.5 h-1.5 rounded-full"
+                style={{ backgroundColor: "var(--color-primary)" }} />
+            )}
+          </button>
+        ))}
+      </div>
+
       {/* Split pane */}
       <div className="flex-1 flex overflow-hidden">
-        {/* Recipe artifact — left */}
-        <div className="flex-1 overflow-hidden border-r"
-          style={{ borderColor: "var(--color-border)" }}>
+        {/* Recipe artifact — left (full width on mobile recipe tab) */}
+        <div
+          className={mobileTab === "recipe" ? "flex flex-col flex-1 overflow-hidden md:border-r" : "hidden md:flex md:flex-col md:flex-1 md:overflow-hidden md:border-r"}
+          style={{ borderColor: "var(--color-border)" }}
+        >
           <RecipeArtifact recipe={recipe} />
         </div>
 
-        {/* Chat panel — right */}
-        <div className="w-96 shrink-0 flex flex-col overflow-hidden">
+        {/* Chat panel — right (full width on mobile chat tab, w-96 on desktop) */}
+        <div className={mobileTab === "chat" ? "flex flex-col flex-1 overflow-hidden md:w-96 md:flex-none" : "hidden md:flex md:flex-col md:w-96 md:shrink-0 md:overflow-hidden"}>
           <ChatPanel
             messages={messages}
             isStreaming={isStreaming}

--- a/recipe-app/components/cooking/CookingRecipeView.tsx
+++ b/recipe-app/components/cooking/CookingRecipeView.tsx
@@ -1,7 +1,7 @@
 "use client"
 
 import { useState } from "react"
-import { ChevronLeft, ChevronRight, Timer, HelpCircle } from "lucide-react"
+import { ChevronLeft, ChevronRight, Timer, HelpCircle, List, X } from "lucide-react"
 import type { Recipe } from "@/types/recipe"
 import { useCookingMode } from "@/lib/hooks/useCookingMode"
 import { CookingHelpDrawer } from "./CookingHelpDrawer"
@@ -12,6 +12,7 @@ interface CookingRecipeViewProps {
 
 export function CookingRecipeView({ recipe }: CookingRecipeViewProps) {
   const [helpOpen, setHelpOpen] = useState(false)
+  const [ingredientsOpen, setIngredientsOpen] = useState(false)
 
   const {
     currentStep,
@@ -26,11 +27,9 @@ export function CookingRecipeView({ recipe }: CookingRecipeViewProps) {
     ingredients,
   } = useCookingMode(recipe.steps, recipe.ingredients)
 
-  // isOnIngredients is used for future phase indicator
-
   return (
     <div className="flex h-full">
-      {/* Ingredients sidebar */}
+      {/* Ingredients sidebar — desktop only */}
       <div className="w-64 shrink-0 border-r overflow-y-auto p-6 hidden lg:block"
         style={{ borderColor: "var(--color-border)" }}>
         <h2 className="text-xs font-semibold uppercase tracking-wide mb-4"
@@ -133,6 +132,18 @@ export function CookingRecipeView({ recipe }: CookingRecipeViewProps) {
           </>
         )}
 
+        {/* Mobile: ingredients button */}
+        {ingredients.length > 0 && (
+          <button
+            onClick={() => setIngredientsOpen(true)}
+            className="lg:hidden mt-8 flex items-center gap-2 px-4 py-2 rounded-full text-sm font-medium border transition-colors"
+            style={{ borderColor: "var(--color-border)", color: "var(--color-muted-foreground)" }}
+          >
+            <List size={15} />
+            Ingredients ({checkedIngredients.size}/{ingredients.length} checked)
+          </button>
+        )}
+
         {/* Help button */}
         <button
           onClick={() => setHelpOpen(true)}
@@ -144,6 +155,69 @@ export function CookingRecipeView({ recipe }: CookingRecipeViewProps) {
         </button>
       </div>
 
+      {/* Mobile: ingredients bottom sheet */}
+      {ingredientsOpen && (
+        <div
+          className="fixed inset-0 z-50 flex flex-col justify-end lg:hidden"
+          style={{ backgroundColor: "rgba(0,0,0,0.4)" }}
+          onClick={() => setIngredientsOpen(false)}
+        >
+          <div
+            className="rounded-t-2xl max-h-[70vh] overflow-y-auto p-6"
+            style={{ backgroundColor: "var(--color-card)" }}
+            onClick={(e) => e.stopPropagation()}
+          >
+            <div className="flex items-center justify-between mb-4">
+              <h2 className="text-sm font-semibold uppercase tracking-wide"
+                style={{ color: "var(--color-muted-foreground)" }}>
+                Ingredients
+              </h2>
+              <button
+                onClick={() => setIngredientsOpen(false)}
+                className="p-1.5 rounded-lg"
+                style={{ color: "var(--color-muted-foreground)" }}
+              >
+                <X size={16} />
+              </button>
+            </div>
+            <ul className="space-y-3">
+              {ingredients.map((ing, i) => (
+                <li key={i} className="flex items-start gap-3">
+                  <button
+                    onClick={() => toggleIngredient(i)}
+                    className="w-5 h-5 rounded mt-0.5 border-2 shrink-0 flex items-center justify-center transition-colors"
+                    style={checkedIngredients.has(i) ? {
+                      backgroundColor: "var(--color-primary)",
+                      borderColor: "var(--color-primary)",
+                    } : {
+                      borderColor: "var(--color-border)",
+                      backgroundColor: "transparent",
+                    }}
+                  >
+                    {checkedIngredients.has(i) && (
+                      <svg width="9" height="9" viewBox="0 0 10 10" fill="white">
+                        <path d="M1.5 5l2.5 2.5L8.5 2" stroke="white" strokeWidth="1.5" strokeLinecap="round" fill="none" />
+                      </svg>
+                    )}
+                  </button>
+                  <span
+                    className="text-sm leading-snug transition-colors"
+                    style={checkedIngredients.has(i)
+                      ? { color: "var(--color-muted-foreground)", textDecoration: "line-through" }
+                      : { color: "var(--color-foreground)" }}
+                  >
+                    <span className="font-medium">{ing.amount} {ing.unit}</span> {ing.name}
+                    {ing.notes && (
+                      <span className="text-xs" style={{ color: "var(--color-muted-foreground)" }}> ({ing.notes})</span>
+                    )}
+                  </span>
+                </li>
+              ))}
+            </ul>
+          </div>
+        </div>
+      )}
+
       {/* Help drawer */}
       {helpOpen && (
         <CookingHelpDrawer
@@ -154,4 +228,3 @@ export function CookingRecipeView({ recipe }: CookingRecipeViewProps) {
     </div>
   )
 }
-

--- a/recipe-app/components/layout/AppHeader.tsx
+++ b/recipe-app/components/layout/AppHeader.tsx
@@ -9,7 +9,7 @@ export function AppHeader() {
   const pathname = usePathname()
 
   const navLinks = [
-    { href: "/", label: "Recipes", icon: BookOpen, match: /^\/$|^\/recipes/ },
+    { href: "/", label: "Recipes", icon: BookOpen, match: /^\/\$|^\/recipes/ },
     { href: "/meals", label: "Meals", icon: Utensils, match: /^\/meals/ },
   ]
 
@@ -19,7 +19,7 @@ export function AppHeader() {
       <Link href="/" className="flex items-center gap-2 font-semibold text-sm shrink-0"
         style={{ color: "var(--color-primary)" }}>
         <ChefHat size={20} />
-        <span>Mise en Place</span>
+        <span className="hidden sm:inline">Mise en Place</span>
       </Link>
 
       <nav className="flex items-center gap-1 flex-1">
@@ -56,7 +56,7 @@ export function AppHeader() {
           style={{ backgroundColor: "var(--color-primary)" }}
         >
           <Plus size={14} />
-          New Recipe
+          <span className="hidden sm:inline">New Recipe</span>
         </Link>
       </div>
     </header>


### PR DESCRIPTION
Makes every page in the recipe app usable on a phone.

## Changes by file

**AppHeader** — logo text and "New Recipe" label hidden on xs screens (just icon + icon-button visible at narrow widths).

**RecipeDetailClient** — Recipe / Chat tab switcher appears on mobile; both panels show side-by-side on md+. A green dot on the Chat tab alerts you when a recipe is ready to save.

**MealDetailClient** — Recipes / Chat tab switcher on mobile; same side-by-side layout on md+.

**NewMealClient** — Meal plan sidebar hidden on mobile. When a plan is ready, a floating orange "View Plan (N)" button appears; tapping opens the plan as a full bottom sheet with the Save Meal button.

**CookingRecipeView** — Ingredients sidebar stays on lg+ screens. On mobile an "Ingredients (X/N checked)" button appears below the nav buttons; tapping opens a bottom sheet where ingredients can be checked off.

**MealCookClient** — Dish list becomes a horizontal scrolling tab row on mobile; vertical sidebar only shows on lg+.

---
_Generated by [Claude Code](https://claude.ai/code/session_012BY9VPHoVJstziT1GHcaZH)_