### PR TITLE
Add Meal Prep mode + rebrand to Mealbot3000 with dark UI

### DIFF
--- a/recipe-app/app/DashboardClient.tsx
+++ b/recipe-app/app/DashboardClient.tsx
@@ -17,18 +17,24 @@ export function DashboardClient() {
 
   return (
     <div className="max-w-6xl mx-auto px-4 py-8">
+
       {/* Recipes section */}
-      <div className="mb-12">
+      <div className="mb-14">
         <div className="flex items-center justify-between mb-5">
-          <h2 className="text-xl font-bold" style={{ color: "var(--color-foreground)" }}>
+          <h2 className="text-xs font-mono font-black uppercase tracking-widest"
+            style={{ color: "var(--color-muted-foreground)" }}>
             Recipes
           </h2>
           <Link
             href="/recipes/new"
-            className="flex items-center gap-1.5 px-3 py-1.5 rounded-lg text-sm font-medium transition-colors"
-            style={{ color: "var(--color-primary)", backgroundColor: "var(--color-accent)" }}
+            className="flex items-center gap-1.5 px-3 py-1.5 rounded-lg text-xs font-semibold font-mono uppercase tracking-wide transition-colors"
+            style={{
+              color: "#C4B5FD",
+              backgroundColor: "rgba(139, 92, 246, 0.12)",
+              border: "1px solid rgba(139, 92, 246, 0.25)",
+            }}
           >
-            <Plus size={14} />
+            <Plus size={13} />
             New Recipe
           </Link>
         </div>
@@ -44,7 +50,7 @@ export function DashboardClient() {
           <EmptyState
             icon={BookOpen}
             title="No recipes yet"
-            description="Start a conversation to create your first recipe. The AI will help you build it step by step."
+            description="Start a conversation to create your first recipe. AI will help you build it step by step."
             action={{ label: "Create first recipe", href: "/recipes/new" }}
           />
         ) : (
@@ -57,17 +63,22 @@ export function DashboardClient() {
       </div>
 
       {/* Meals section */}
-      <div className="mb-12">
+      <div className="mb-14">
         <div className="flex items-center justify-between mb-5">
-          <h2 className="text-xl font-bold" style={{ color: "var(--color-foreground)" }}>
+          <h2 className="text-xs font-mono font-black uppercase tracking-widest"
+            style={{ color: "var(--color-muted-foreground)" }}>
             Meals
           </h2>
           <Link
             href="/meals/new"
-            className="flex items-center gap-1.5 px-3 py-1.5 rounded-lg text-sm font-medium transition-colors"
-            style={{ color: "#C2410C", backgroundColor: "#FFF7ED" }}
+            className="flex items-center gap-1.5 px-3 py-1.5 rounded-lg text-xs font-semibold font-mono uppercase tracking-wide transition-colors"
+            style={{
+              color: "#FB923C",
+              backgroundColor: "rgba(251, 146, 60, 0.1)",
+              border: "1px solid rgba(251, 146, 60, 0.25)",
+            }}
           >
-            <Plus size={14} />
+            <Plus size={13} />
             New Meal
           </Link>
         </div>
@@ -98,15 +109,20 @@ export function DashboardClient() {
       {/* Meal Prep section */}
       <div>
         <div className="flex items-center justify-between mb-5">
-          <h2 className="text-xl font-bold" style={{ color: "var(--color-foreground)" }}>
+          <h2 className="text-xs font-mono font-black uppercase tracking-widest"
+            style={{ color: "var(--color-muted-foreground)" }}>
             Meal Prep
           </h2>
           <Link
             href="/meal-prep/new"
-            className="flex items-center gap-1.5 px-3 py-1.5 rounded-lg text-sm font-medium transition-colors"
-            style={{ color: "#065F46", backgroundColor: "#ECFDF5" }}
+            className="flex items-center gap-1.5 px-3 py-1.5 rounded-lg text-xs font-semibold font-mono uppercase tracking-wide transition-colors"
+            style={{
+              color: "#22D3EE",
+              backgroundColor: "rgba(6, 182, 212, 0.1)",
+              border: "1px solid rgba(6, 182, 212, 0.25)",
+            }}
           >
-            <Plus size={14} />
+            <Plus size={13} />
             New Prep
           </Link>
         </div>

--- a/recipe-app/app/globals.css
+++ b/recipe-app/app/globals.css
@@ -1,23 +1,23 @@
 @import "tailwindcss";
 
 @theme {
-  --color-background: #FAFAF8;
-  --color-foreground: #1C1C1C;
-  --color-card: #FFFFFF;
-  --color-card-foreground: #1C1C1C;
-  --color-muted: #F4F4F2;
-  --color-muted-foreground: #737373;
-  --color-border: #E5E5E3;
-  --color-input: #E5E5E3;
-  --color-primary: #2D6A4F;
+  --color-background: #070710;
+  --color-foreground: #EEEEF5;
+  --color-card: #0D0D1C;
+  --color-card-foreground: #EEEEF5;
+  --color-muted: #14142A;
+  --color-muted-foreground: #7070A0;
+  --color-border: #1E1E38;
+  --color-input: #1E1E38;
+  --color-primary: #8B5CF6;
   --color-primary-foreground: #FFFFFF;
-  --color-primary-hover: #245740;
-  --color-accent: #F0FDF4;
-  --color-accent-foreground: #2D6A4F;
-  --color-destructive: #DC2626;
+  --color-primary-hover: #7C3AED;
+  --color-accent: #1C1040;
+  --color-accent-foreground: #C4B5FD;
+  --color-destructive: #EF4444;
   --color-destructive-foreground: #FFFFFF;
-  --color-ring: #2D6A4F;
-  --color-sidebar: #F8F8F6;
+  --color-ring: #8B5CF6;
+  --color-sidebar: #090918;
 
   --radius: 0.625rem;
   --radius-sm: 0.375rem;
@@ -31,10 +31,42 @@
 
 body {
   background-color: var(--color-background);
+  background-image: radial-gradient(rgba(139, 92, 246, 0.06) 1px, transparent 1px);
+  background-size: 28px 28px;
   color: var(--color-foreground);
   font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, sans-serif;
   -webkit-font-smoothing: antialiased;
   -moz-osx-font-smoothing: grayscale;
+}
+
+/* Gradient utilities */
+.gradient-text {
+  background: linear-gradient(135deg, #A78BFA 0%, #22D3EE 85%);
+  -webkit-background-clip: text;
+  -webkit-text-fill-color: transparent;
+  background-clip: text;
+}
+
+.gradient-bg {
+  background: linear-gradient(135deg, #7C3AED 0%, #0891B2 100%);
+}
+
+/* Card glow on hover */
+.card-hover {
+  transition: border-color 0.2s, box-shadow 0.2s;
+}
+.card-hover:hover {
+  border-color: rgba(139, 92, 246, 0.4) !important;
+  box-shadow: 0 0 28px rgba(139, 92, 246, 0.1);
+}
+
+/* Primary glow button */
+.btn-glow {
+  box-shadow: 0 0 18px rgba(139, 92, 246, 0.35);
+  transition: opacity 0.2s, box-shadow 0.2s;
+}
+.btn-glow:hover {
+  box-shadow: 0 0 28px rgba(139, 92, 246, 0.55);
 }
 
 @keyframes blink {

--- a/recipe-app/app/layout.tsx
+++ b/recipe-app/app/layout.tsx
@@ -4,8 +4,8 @@ import { AppHeader } from "@/components/layout/AppHeader"
 import { Toaster } from "@/components/layout/Toaster"
 
 export const metadata: Metadata = {
-  title: "Mise en Place — AI Recipe & Meal Planner",
-  description: "Chat with AI to create, manage, and cook recipes and meals.",
+  title: "Mealbot3000 — AI Recipe & Meal Planner",
+  description: "AI-powered recipes, meals, and meal prep. Chat your way to better eating.",
 }
 
 export default function RootLayout({

--- a/recipe-app/app/meal-prep/MealPrepListClient.tsx
+++ b/recipe-app/app/meal-prep/MealPrepListClient.tsx
@@ -17,8 +17,8 @@ export function MealPrepListClient() {
         </h1>
         <Link
           href="/meal-prep/new"
-          className="flex items-center gap-1.5 px-3 py-1.5 rounded-lg text-sm font-medium transition-colors"
-          style={{ color: "#065F46", backgroundColor: "#ECFDF5" }}
+          className="flex items-center gap-1.5 px-3 py-1.5 rounded-lg text-xs font-semibold font-mono uppercase tracking-wide transition-colors"
+          style={{ color: "#22D3EE", backgroundColor: "rgba(6,182,212,0.1)", border: "1px solid rgba(6,182,212,0.25)" }}
         >
           <Plus size={14} />
           New Prep

--- a/recipe-app/app/meal-prep/[id]/MealPrepDetailClient.tsx
+++ b/recipe-app/app/meal-prep/[id]/MealPrepDetailClient.tsx
@@ -65,7 +65,7 @@ export function MealPrepDetailClient({ id }: MealPrepDetailClientProps) {
     return (
       <div className="flex items-center justify-center h-[calc(100vh-56px)]">
         <div className="w-8 h-8 rounded-full border-2 border-t-transparent animate-spin"
-          style={{ borderColor: "var(--color-border)", borderTopColor: "#059669" }} />
+          style={{ borderColor: "var(--color-border)", borderTopColor: "#0891B2" }} />
       </div>
     )
   }
@@ -74,7 +74,7 @@ export function MealPrepDetailClient({ id }: MealPrepDetailClientProps) {
     return (
       <div className="flex flex-col items-center justify-center h-[calc(100vh-56px)] gap-4">
         <p style={{ color: "var(--color-muted-foreground)" }}>Meal prep not found.</p>
-        <Link href="/" className="text-sm font-medium" style={{ color: "#059669" }}>
+        <Link href="/" className="text-sm font-medium" style={{ color: "#0891B2" }}>
           Back to dashboard
         </Link>
       </div>
@@ -127,8 +127,8 @@ export function MealPrepDetailClient({ id }: MealPrepDetailClientProps) {
             onClick={() => setMobileTab(tab)}
             className="flex-1 py-2.5 text-sm font-medium transition-colors"
             style={mobileTab === tab ? {
-              color: "#059669",
-              borderBottom: "2px solid #059669",
+              color: "#0891B2",
+              borderBottom: "2px solid #0891B2",
             } : { color: "var(--color-muted-foreground)" }}
           >
             {label}

--- a/recipe-app/app/meal-prep/new/NewMealPrepClient.tsx
+++ b/recipe-app/app/meal-prep/new/NewMealPrepClient.tsx
@@ -158,7 +158,7 @@ export function NewMealPrepClient() {
         <button
           onClick={() => setShowPlanSheet(true)}
           className="md:hidden fixed bottom-20 right-4 flex items-center gap-2 px-4 py-2.5 rounded-full text-sm font-semibold text-white shadow-lg z-30 transition-opacity hover:opacity-90"
-          style={{ backgroundColor: "#059669" }}
+          style={{ background: "linear-gradient(135deg, #0891B2 0%, #0E7490 100%)" }}
         >
           <Dumbbell size={15} />
           View Plan ({activePlan.suggestions.length})
@@ -249,13 +249,13 @@ function PrepPlanContent({ plan, saving, onClear, onSave }: PrepPlanContentProps
                 </p>
               )}
               {s.recipeId && (
-                <p className="text-xs mt-0.5" style={{ color: "#059669" }}>
+                <p className="text-xs mt-0.5" style={{ color: "#0891B2" }}>
                   Using saved recipe
                 </p>
               )}
             </div>
             {s.recipeId && (
-              <Check size={14} className="shrink-0 mt-0.5" style={{ color: "#059669" }} />
+              <Check size={14} className="shrink-0 mt-0.5" style={{ color: "#0891B2" }} />
             )}
           </div>
         ))}
@@ -265,7 +265,7 @@ function PrepPlanContent({ plan, saving, onClear, onSave }: PrepPlanContentProps
         onClick={onSave}
         disabled={saving}
         className="w-full flex items-center justify-center gap-2 py-2.5 rounded-xl text-sm font-semibold text-white transition-opacity disabled:opacity-60 hover:opacity-90"
-        style={{ backgroundColor: "#059669" }}
+        style={{ background: "linear-gradient(135deg, #0891B2 0%, #0E7490 100%)" }}
       >
         <Plus size={15} />
         {saving ? "Saving…" : "Save Meal Prep"}

--- a/recipe-app/app/meals/MealsClient.tsx
+++ b/recipe-app/app/meals/MealsClient.tsx
@@ -17,8 +17,8 @@ export function MealsClient() {
         </h1>
         <Link
           href="/meals/new"
-          className="flex items-center gap-1.5 px-3 py-1.5 rounded-lg text-sm font-medium transition-colors"
-          style={{ color: "#C2410C", backgroundColor: "#FFF7ED" }}
+          className="flex items-center gap-1.5 px-3 py-1.5 rounded-lg text-xs font-semibold font-mono uppercase tracking-wide transition-colors"
+          style={{ color: "#FB923C", backgroundColor: "rgba(251,146,60,0.1)", border: "1px solid rgba(251,146,60,0.25)" }}
         >
           <Plus size={14} />
           New Meal

--- a/recipe-app/app/meals/[id]/MealDetailClient.tsx
+++ b/recipe-app/app/meals/[id]/MealDetailClient.tsx
@@ -102,7 +102,7 @@ export function MealDetailClient({ id }: MealDetailClientProps) {
         <Link
           href={`/meals/${meal.id}/cook`}
           className="shrink-0 flex items-center gap-1.5 px-3 py-1.5 rounded-xl text-sm font-medium text-white transition-opacity hover:opacity-90"
-          style={{ backgroundColor: "#EA580C" }}
+          style={{ background: "linear-gradient(135deg, #EA580C 0%, #DC2626 100%)" }}
         >
           <ChefHat size={14} />
           Cook

--- a/recipe-app/app/meals/new/NewMealClient.tsx
+++ b/recipe-app/app/meals/new/NewMealClient.tsx
@@ -159,7 +159,7 @@ export function NewMealClient() {
         <button
           onClick={() => setShowPlanSheet(true)}
           className="md:hidden fixed bottom-20 right-4 flex items-center gap-2 px-4 py-2.5 rounded-full text-sm font-semibold text-white shadow-lg z-30 transition-opacity hover:opacity-90"
-          style={{ backgroundColor: "#EA580C" }}
+          style={{ background: "linear-gradient(135deg, #EA580C 0%, #DC2626 100%)" }}
         >
           <Utensils size={15} />
           View Plan ({activePlan.suggestions.length})
@@ -266,7 +266,7 @@ function PlanContent({ plan, saving, onClear, onSave }: PlanContentProps) {
         onClick={onSave}
         disabled={saving}
         className="w-full flex items-center justify-center gap-2 py-2.5 rounded-xl text-sm font-semibold text-white transition-opacity disabled:opacity-60 hover:opacity-90"
-        style={{ backgroundColor: "#EA580C" }}
+        style={{ background: "linear-gradient(135deg, #EA580C 0%, #DC2626 100%)" }}
       >
         <Plus size={15} />
         {saving ? "Saving…" : "Save Meal"}

--- a/recipe-app/components/layout/AppHeader.tsx
+++ b/recipe-app/components/layout/AppHeader.tsx
@@ -2,25 +2,35 @@
 
 import Link from "next/link"
 import { usePathname } from "next/navigation"
-import { ChefHat, BookOpen, Utensils, Dumbbell, Plus } from "lucide-react"
+import { Bot, BookOpen, Utensils, Dumbbell, Plus } from "lucide-react"
 import { cn } from "@/lib/utils/cn"
 
 export function AppHeader() {
   const pathname = usePathname()
 
   const navLinks = [
-    { href: "/", label: "Recipes", icon: BookOpen, match: /^\/\$|^\/recipes/ },
+    { href: "/", label: "Recipes", icon: BookOpen, match: /^\/$|^\/recipes/ },
     { href: "/meals", label: "Meals", icon: Utensils, match: /^\/meals/ },
     { href: "/meal-prep", label: "Prep", icon: Dumbbell, match: /^\/meal-prep/ },
   ]
 
   return (
-    <header className="sticky top-0 z-40 h-14 border-b flex items-center px-4 gap-6"
-      style={{ borderColor: "var(--color-border)", backgroundColor: "var(--color-card)" }}>
-      <Link href="/" className="flex items-center gap-2 font-semibold text-sm shrink-0"
-        style={{ color: "var(--color-primary)" }}>
-        <ChefHat size={20} />
-        <span className="hidden sm:inline">Mise en Place</span>
+    <header
+      className="sticky top-0 z-40 h-14 border-b flex items-center px-4 gap-4"
+      style={{
+        borderColor: "rgba(139, 92, 246, 0.15)",
+        backgroundColor: "rgba(7, 7, 16, 0.88)",
+        backdropFilter: "blur(14px)",
+        WebkitBackdropFilter: "blur(14px)",
+      }}
+    >
+      <Link href="/" className="flex items-center gap-2 shrink-0">
+        <div className="w-7 h-7 rounded-lg flex items-center justify-center gradient-bg shrink-0">
+          <Bot size={15} className="text-white" />
+        </div>
+        <span className="hidden sm:inline font-mono font-black text-sm tracking-widest gradient-text select-none">
+          MEALBOT3000
+        </span>
       </Link>
 
       <nav className="flex items-center gap-1 flex-1">
@@ -31,17 +41,21 @@ export function AppHeader() {
               key={link.href}
               href={link.href}
               className={cn(
-                "flex items-center gap-1.5 px-3 py-1.5 rounded-md text-sm font-medium transition-colors",
-                active
-                  ? "text-primary bg-accent"
-                  : "text-muted-foreground hover:text-foreground hover:bg-muted"
+                "flex items-center gap-1.5 px-3 py-1.5 rounded-md text-sm font-medium transition-all",
+                active ? "" : "hover:bg-white/5"
               )}
-              style={active ? {
-                color: "var(--color-primary)",
-                backgroundColor: "var(--color-accent)",
-              } : {
-                color: "var(--color-muted-foreground)",
-              }}
+              style={
+                active
+                  ? {
+                      background: "rgba(139, 92, 246, 0.14)",
+                      color: "#C4B5FD",
+                      border: "1px solid rgba(139, 92, 246, 0.35)",
+                    }
+                  : {
+                      color: "var(--color-muted-foreground)",
+                      border: "1px solid transparent",
+                    }
+              }
             >
               <link.icon size={15} />
               {link.label}
@@ -50,16 +64,13 @@ export function AppHeader() {
         })}
       </nav>
 
-      <div className="flex items-center gap-2">
-        <Link
-          href="/recipes/new"
-          className="flex items-center gap-1.5 px-3 py-1.5 rounded-md text-sm font-medium text-white transition-colors"
-          style={{ backgroundColor: "var(--color-primary)" }}
-        >
-          <Plus size={14} />
-          <span className="hidden sm:inline">New Recipe</span>
-        </Link>
-      </div>
+      <Link
+        href="/recipes/new"
+        className="flex items-center gap-1.5 px-3 py-1.5 rounded-md text-sm font-semibold text-white gradient-bg btn-glow shrink-0"
+      >
+        <Plus size={14} />
+        <span className="hidden sm:inline">New Recipe</span>
+      </Link>
     </header>
   )
 }

--- a/recipe-app/components/meal-prep/MacroSummary.tsx
+++ b/recipe-app/components/meal-prep/MacroSummary.tsx
@@ -55,7 +55,7 @@ export function MacroSummary({ entries }: MacroSummaryProps) {
 
   return (
     <div className="rounded-2xl border p-4"
-      style={{ borderColor: "var(--color-border)", backgroundColor: "var(--color-card)" }}>
+      style={{ borderColor: "rgba(139,92,246,0.2)", backgroundColor: "var(--color-card)" }}>
       <h3 className="text-xs font-semibold uppercase tracking-wide mb-3"
         style={{ color: "var(--color-muted-foreground)" }}>
         Daily Averages

--- a/recipe-app/components/meal-prep/MealPrepCard.tsx
+++ b/recipe-app/components/meal-prep/MealPrepCard.tsx
@@ -15,13 +15,13 @@ export function MealPrepCard({ mealPrep }: MealPrepCardProps) {
   return (
     <Link
       href={`/meal-prep/${mealPrep.id}`}
-      className="block rounded-2xl border p-4 transition-colors hover:bg-muted/50"
+      className="block rounded-2xl border p-4 card-hover"
       style={{ borderColor: "var(--color-border)", backgroundColor: "var(--color-card)" }}
     >
       <div className="flex items-start gap-3">
-        <div className="p-2 rounded-lg shrink-0"
-          style={{ backgroundColor: "#ECFDF5", color: "#059669" }}>
-          <Dumbbell size={16} />
+        <div className="w-9 h-9 rounded-xl flex items-center justify-center shrink-0"
+          style={{ backgroundColor: "rgba(6, 182, 212, 0.15)", color: "#22D3EE" }}>
+          <Dumbbell size={17} />
         </div>
         <div className="flex-1 min-w-0">
           <p className="text-sm font-semibold truncate" style={{ color: "var(--color-foreground)" }}>
@@ -33,11 +33,13 @@ export function MealPrepCard({ mealPrep }: MealPrepCardProps) {
             </p>
           )}
           <div className="flex items-center gap-3 mt-2">
-            <span className="text-xs" style={{ color: "var(--color-muted-foreground)" }}>
+            <span className="text-xs font-mono"
+              style={{ color: "#22D3EE" }}>
               {recipeCount} dish{recipeCount !== 1 ? "es" : ""}
             </span>
-            <span className="text-xs" style={{ color: "var(--color-muted-foreground)" }}>
-              {totalServings} servings/week
+            <span className="text-xs font-mono"
+              style={{ color: "var(--color-muted-foreground)" }}>
+              {totalServings} servings/wk
             </span>
           </div>
         </div>

--- a/recipe-app/components/meal-prep/MealPrepRecipeList.tsx
+++ b/recipe-app/components/meal-prep/MealPrepRecipeList.tsx
@@ -29,18 +29,18 @@ export function MealPrepRecipeList({ recipeRefs, recipes }: MealPrepRecipeListPr
         return (
           <div key={i} className="flex items-start gap-3 p-3 rounded-xl border"
             style={{
-              borderColor: isStub ? "#A7F3D0" : "var(--color-border)",
-              backgroundColor: isStub ? "#ECFDF5" : "var(--color-card)",
+              borderColor: isStub ? "rgba(6,182,212,0.3)" : "var(--color-border)",
+              backgroundColor: isStub ? "rgba(6,182,212,0.06)" : "var(--color-muted)",
             }}>
             <div className="w-8 h-8 rounded-lg flex items-center justify-center shrink-0 mt-0.5"
-              style={{ backgroundColor: "#ECFDF5", color: "#059669" }}>
+              style={{ backgroundColor: "rgba(6,182,212,0.15)", color: "#22D3EE" }}>
               <Dumbbell size={15} />
             </div>
 
             <div className="flex-1 min-w-0">
               <div className="flex items-center gap-2 flex-wrap">
                 <span className="text-xs font-medium px-2 py-0.5 rounded-full"
-                  style={{ backgroundColor: "#ECFDF5", color: "#059669" }}>
+                  style={{ backgroundColor: "rgba(6,182,212,0.15)", color: "#22D3EE" }}>
                   {ref.servingsPerWeek}×/week
                 </span>
                 {isStub && (
@@ -87,10 +87,11 @@ export function MealPrepRecipeList({ recipeRefs, recipes }: MealPrepRecipeListPr
                 href={`/recipes/${ref.recipeId}`}
                 className="shrink-0 flex items-center gap-1 px-2.5 py-1.5 rounded-lg text-xs font-medium transition-colors mt-0.5"
                 style={isStub ? {
-                  backgroundColor: "#059669",
+                  backgroundColor: "#0891B2",
                   color: "white",
                 } : {
                   color: "var(--color-muted-foreground)",
+                  backgroundColor: "var(--color-border)",
                 }}
                 title={isStub ? "Generate recipe" : "View recipe"}
                 onClick={(e) => e.stopPropagation()}

--- a/recipe-app/components/meal/MealCard.tsx
+++ b/recipe-app/components/meal/MealCard.tsx
@@ -10,11 +10,11 @@ interface MealCardProps {
   meal: Meal
 }
 
-const roleEmoji: Record<string, string> = {
-  main: "🍽️",
-  side: "🥗",
-  dessert: "🍰",
-  drink: "🥤",
+const roleLabel: Record<string, string> = {
+  main: "main",
+  side: "side",
+  dessert: "dessert",
+  drink: "drink",
 }
 
 export function MealCard({ meal }: MealCardProps) {
@@ -33,13 +33,13 @@ export function MealCard({ meal }: MealCardProps) {
   return (
     <Link href={`/meals/${meal.id}`} className="block group">
       <div
-        className="rounded-2xl p-5 border transition-shadow hover:shadow-md relative"
+        className="rounded-2xl p-5 border card-hover relative"
         style={{ backgroundColor: "var(--color-card)", borderColor: "var(--color-border)" }}
       >
         <button
           onClick={handleDelete}
-          className="absolute top-3 right-3 opacity-0 group-hover:opacity-100 transition-opacity p-1.5 rounded-lg hover:bg-red-50"
-          style={{ color: "var(--color-destructive)" }}
+          className="absolute top-3 right-3 opacity-0 group-hover:opacity-100 transition-opacity p-1.5 rounded-lg"
+          style={{ color: "var(--color-destructive)", backgroundColor: "rgba(239,68,68,0.1)" }}
           title="Delete meal"
         >
           <Trash2 size={14} />
@@ -47,8 +47,8 @@ export function MealCard({ meal }: MealCardProps) {
 
         <div className="flex items-start gap-3 mb-3">
           <div className="w-9 h-9 rounded-xl flex items-center justify-center shrink-0"
-            style={{ backgroundColor: "#FFF7ED", color: "#EA580C" }}>
-            <Utensils size={18} />
+            style={{ backgroundColor: "rgba(251, 146, 60, 0.15)", color: "#FB923C" }}>
+            <Utensils size={17} />
           </div>
           <div className="min-w-0">
             <h3 className="font-semibold text-sm leading-snug truncate pr-6"
@@ -67,9 +67,13 @@ export function MealCard({ meal }: MealCardProps) {
         {meal.recipeRefs.length > 0 && (
           <div className="flex flex-wrap gap-1 mt-2">
             {meal.recipeRefs.map((ref, i) => (
-              <span key={i} className="text-xs px-2 py-0.5 rounded-full"
-                style={{ backgroundColor: "var(--color-muted)", color: "var(--color-muted-foreground)" }}>
-                {roleEmoji[ref.role] ?? "•"} {ref.role}
+              <span key={i} className="text-xs px-2 py-0.5 rounded-full font-mono"
+                style={{
+                  backgroundColor: "rgba(251, 146, 60, 0.1)",
+                  color: "#FB923C",
+                  border: "1px solid rgba(251, 146, 60, 0.2)",
+                }}>
+                {roleLabel[ref.role] ?? ref.role}
               </span>
             ))}
           </div>

--- a/recipe-app/components/meal/MealRecipeList.tsx
+++ b/recipe-app/components/meal/MealRecipeList.tsx
@@ -17,11 +17,11 @@ const roleLabel: Record<string, string> = {
   drink: "Drink",
 }
 
-const roleColor: Record<string, { bg: string; text: string }> = {
-  main: { bg: "var(--color-accent)", text: "var(--color-primary)" },
-  side: { bg: "#F0F9FF", text: "#0369A1" },
-  dessert: { bg: "#FDF4FF", text: "#A21CAF" },
-  drink: { bg: "#FFF7ED", text: "#C2410C" },
+const roleColor: Record<string, { bg: string; text: string; border: string }> = {
+  main: { bg: "rgba(139,92,246,0.12)", text: "#C4B5FD", border: "rgba(139,92,246,0.25)" },
+  side: { bg: "rgba(14,165,233,0.12)", text: "#38BDF8", border: "rgba(14,165,233,0.25)" },
+  dessert: { bg: "rgba(192,38,211,0.12)", text: "#E879F9", border: "rgba(192,38,211,0.25)" },
+  drink: { bg: "rgba(251,146,60,0.12)", text: "#FB923C", border: "rgba(251,146,60,0.25)" },
 }
 
 export function MealRecipeList({ recipeRefs, recipes }: MealRecipeListProps) {
@@ -47,8 +47,8 @@ export function MealRecipeList({ recipeRefs, recipes }: MealRecipeListProps) {
         return (
           <div key={i} className="flex items-center gap-3 p-3 rounded-xl border"
             style={{
-              borderColor: isStub ? "#FED7AA" : "var(--color-border)",
-              backgroundColor: isStub ? "#FFF7ED" : "var(--color-card)",
+              borderColor: isStub ? "rgba(251,146,60,0.3)" : "var(--color-border)",
+              backgroundColor: isStub ? "rgba(251,146,60,0.06)" : "var(--color-muted)",
             }}>
             <div className="w-8 h-8 rounded-lg flex items-center justify-center shrink-0"
               style={{ backgroundColor: colors.bg, color: colors.text }}>
@@ -56,13 +56,13 @@ export function MealRecipeList({ recipeRefs, recipes }: MealRecipeListProps) {
             </div>
             <div className="flex-1 min-w-0">
               <div className="flex items-center gap-2">
-                <span className="text-xs font-medium px-2 py-0.5 rounded-full"
-                  style={{ backgroundColor: colors.bg, color: colors.text }}>
+                <span className="text-xs font-medium px-2 py-0.5 rounded-full font-mono"
+                  style={{ backgroundColor: colors.bg, color: colors.text, border: `1px solid ${colors.border}` }}>
                   {roleLabel[ref.role]}
                 </span>
                 {isStub && (
-                  <span className="text-xs font-medium" style={{ color: "#C2410C" }}>
-                    Not generated yet
+                  <span className="text-xs font-medium" style={{ color: "#FB923C" }}>
+                    Generating…
                   </span>
                 )}
               </div>
@@ -86,6 +86,7 @@ export function MealRecipeList({ recipeRefs, recipes }: MealRecipeListProps) {
                   color: "white",
                 } : {
                   color: "var(--color-muted-foreground)",
+                  backgroundColor: "var(--color-border)",
                 }}
                 title={isStub ? "Generate recipe" : "View recipe"}
                 onClick={(e) => e.stopPropagation()}

--- a/recipe-app/components/recipe/RecipeCard.tsx
+++ b/recipe-app/components/recipe/RecipeCard.tsx
@@ -28,22 +28,23 @@ export function RecipeCard({ recipe }: RecipeCardProps) {
   return (
     <Link href={`/recipes/${recipe.id}`} className="block group">
       <div
-        className="rounded-2xl p-5 border transition-shadow hover:shadow-md relative overflow-hidden"
+        className="rounded-2xl p-5 border card-hover relative overflow-hidden"
         style={{ backgroundColor: "var(--color-card)", borderColor: "var(--color-border)" }}
       >
         <button
           onClick={handleDelete}
-          className="absolute top-3 right-3 opacity-0 group-hover:opacity-100 transition-opacity p-1.5 rounded-lg hover:bg-red-50"
-          style={{ color: "var(--color-destructive)" }}
+          className="absolute top-3 right-3 opacity-0 group-hover:opacity-100 transition-opacity p-1.5 rounded-lg"
+          style={{ color: "var(--color-destructive)", backgroundColor: "rgba(239,68,68,0.1)" }}
           title="Delete recipe"
         >
           <Trash2 size={14} />
         </button>
 
         <div className="flex items-start gap-3 mb-3">
-          <div className="w-9 h-9 rounded-xl flex items-center justify-center shrink-0"
-            style={{ backgroundColor: "var(--color-accent)", color: "var(--color-primary)" }}>
-            <ChefHat size={18} />
+          <div
+            className="w-9 h-9 rounded-xl flex items-center justify-center shrink-0 gradient-bg"
+          >
+            <ChefHat size={17} className="text-white" />
           </div>
           <div className="min-w-0">
             <h3 className="font-semibold text-sm leading-snug truncate pr-6"
@@ -82,8 +83,12 @@ export function RecipeCard({ recipe }: RecipeCardProps) {
             {recipe.tags.slice(0, 4).map((tag) => (
               <span
                 key={tag}
-                className="px-2 py-0.5 rounded-full text-xs"
-                style={{ backgroundColor: "var(--color-accent)", color: "var(--color-accent-foreground)" }}
+                className="px-2 py-0.5 rounded-full text-xs font-mono"
+                style={{
+                  backgroundColor: "rgba(139, 92, 246, 0.12)",
+                  color: "#C4B5FD",
+                  border: "1px solid rgba(139, 92, 246, 0.2)",
+                }}
               >
                 {tag}
               </span>


### PR DESCRIPTION
## Summary

- **Meal Prep mode**: New third planning mode for fitness-focused weekly meal prep. AI suggests dishes with servings-per-week and estimated macros; saves stubs and auto-generates recipes in the background. Detail view shows a MacroSummary with daily-average tiles (calories/protein/carbs/fat), P/C/F ratio bar, and weekly totals that update reactively as recipes generate.
- **Macro fix**: `estimatedMacros` from the AI plan are now stored on each `MealPrepRecipeRef` so the summary shows immediately — no waiting for recipes to generate.
- **Rebrand to Mealbot3000**: New name, `Bot` icon, monospace gradient header.
- **Dark futuristic UI**: Deep purple-black theme with dot-grid background, gradient utilities (`gradient-text`, `gradient-bg`, `card-hover` glow, `btn-glow`), frosted-glass header, and three-section accent system (purple → orange → cyan).

## Test plan

- [ ] Create a new Meal Prep via chat, verify macro summary appears immediately on the detail page
- [ ] Verify recipes auto-generate in the background; macro tiles update as they complete
- [ ] Check dashboard shows all three sections (Recipes, Meals, Meal Prep)
- [ ] Verify "MEALBOT3000" branding in header on desktop and mobile
- [ ] Check dark theme renders correctly — no white/light backgrounds visible
- [ ] Verify Prep nav link is active when on `/meal-prep` routes

---
_Generated by [Claude Code](https://claude.ai/code/session_012BY9VPHoVJstziT1GHcaZH)_